### PR TITLE
add interface, doc updates, configurable http client name

### DIFF
--- a/Frenetik.iRacingApiWrapper/Frenetik.iRacingApiWrapper.csproj
+++ b/Frenetik.iRacingApiWrapper/Frenetik.iRacingApiWrapper.csproj
@@ -10,7 +10,7 @@
     <EmbedAllSources>true</EmbedAllSources>
     <DebugType>portable</DebugType>
     <PackageId>Frenetik.iRacingApiWrapper</PackageId>
-    <Version>2.0.0</Version>
+    <Version>4.2.0</Version>
     <Authors>Mike Ruhl</Authors>
     <Company>Frenetik</Company>
     <Description>A wrapper for the iRacing API</Description>

--- a/Frenetik.iRacingApiWrapper/IIRacingApiService.cs
+++ b/Frenetik.iRacingApiWrapper/IIRacingApiService.cs
@@ -1,0 +1,528 @@
+﻿using Frenetik.iRacingApiWrapper.Enums;
+using Frenetik.iRacingApiWrapper.Models;
+
+namespace Frenetik.iRacingApiWrapper
+{
+    public interface IIRacingApiService
+    {
+        /// <summary>
+        /// Get car assets
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<CarAsset>> GetCarAssets();
+
+        /// <summary>
+        /// Get car classes
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<CarClass>> GetCarClasses();
+
+        /// <summary>
+        /// Get cars
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<Car>> GetCars();
+
+        /// <summary>
+        /// Some responses have a chunk_info property which contains a base_download_url and a list of chunk_file_names.  This method will retrieve the chunked data and return it as a list of lists.
+        /// </summary>
+        /// <typeparam name="T">Chunk Info's response data type</typeparam>
+        /// <param name="chunkedObject"></param>
+        /// <returns></returns>
+        Task<List<T>> GetChunkInfoData<T>(IChunkInfo<T> chunkedObject) where T : class;
+
+        /// <summary>
+        /// Some responses have a chunk_info property which contains a base_download_url and a list of chunk_file_names.
+        /// This method will retrieve the chunked data and return it as an async enumerable of lists.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="chunkedObject"></param>
+        /// <returns></returns>
+        IAsyncEnumerable<List<T>> GetChunkInfoDataPageAsyncEnumerable<T>(IChunkInfo<T> chunkedObject) where T : class;
+
+        /// <summary>
+        /// Get Category constants
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<Constant>> GetConstantsCategories();
+
+        /// <summary>
+        /// Get Division constants
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<Constant>> GetConstantsDivisions();
+
+        /// <summary>
+        /// Get EventType constants
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<Constant>> GetConstantsEventTypes();
+
+        /// <summary>
+        /// Get Cust League Session Results
+        /// </summary>
+        /// <param name="mine">If true, return only sessions created by this user.</param>
+        /// <param name="packageId">If set, return only sessions using this car or track package ID.</param>
+        /// <returns></returns>
+        Task<SessionResult> GetCustLeagueSessionResults(bool mine = false, int? packageId = null);
+
+        /// <summary>
+        /// Gets documentation for all available endpoints, including required and optional parameters.
+        /// Each endpoint is a dictionary with the key being the endpoint name and the value being a dictionary of the endpoint details.
+        /// </summary>
+        /// <returns></returns>
+        Task<Dictionary<string, Dictionary<string, EndpointDetails>>> GetDoc();
+
+        /// <summary>
+        /// Get hosted combined session by package id
+        /// </summary>
+        /// <param name="packageId"></param>
+        /// <returns></returns>
+        Task<SessionResult> GetHostedCombinedSession(int packageId);
+
+        /// <summary>
+        /// Get hosted combined sessions
+        /// </summary>
+        /// <returns></returns>
+        Task<SessionResult> GetHostedCombinedSessions();
+
+        /// <summary>
+        /// Get hosted sessions
+        /// </summary>
+        /// <returns></returns>
+        Task<SessionResult> GetHostedSessions();
+
+        /// <summary>
+        /// Get League by ID
+        /// </summary>
+        /// <param name="leagueId">League Id (required).</param>
+        /// <param name="includeLicenses">For faster responses, only request when necessary.</param>
+        /// <returns></returns>
+        Task<LeagueDetailed> GetLeagueById(int leagueId, bool? includeLicenses = null);
+
+        /// <summary>
+        /// Get LeagueMembership by Customer Id
+        /// </summary>
+        /// <param name="customerId">If different from the authenticated member, the following resrictions apply: <para />
+        /// - Caller cannot be on requested customer's block list or an empty list will result;<para />
+        /// - Requested customer cannot have their online activity prefrence set to hidden or an empty list will result;<para />
+        /// - Only leagues for which the requested customer is an admin and the league roster is not private are returned.</param>
+        /// <param name="includeLeague"></param>
+        /// <returns></returns>
+        Task<List<LeagueMembership>> GetLeagueMembership(int customerId, bool? includeLeague = null);
+
+        /// <summary>
+        /// Returns a League's Seasons
+        /// </summary>
+        /// <param name="leagueId">League Id</param>
+        /// <param name="retired">If true include seasons which are no longer active.</param>
+        /// <returns></returns>
+        Task<LeagueSeasonResult> GetLeagueSeasons(int leagueId, bool? retired = null);
+
+        /// <summary>
+        /// Get league season sessions
+        /// </summary>
+        /// <param name="leagueId">League Id</param>
+        /// <param name="seasonId">Season Id</param>
+        /// <param name="resultsOnly">If true include only sessions for which results are available.</param>
+        /// <returns></returns>
+        Task<LeagueSeasonSessionsResult> GetLeagueSeasonsSessions(int leagueId, int seasonId, bool? resultsOnly = null);
+
+        /// <summary>
+        /// Get League Season Standings
+        /// </summary>
+        /// <param name="leagueId">League Id</param>
+        /// <param name="seasonId">Season Id</param>
+        /// <param name="carClassId"></param>
+        /// <param name="carId">If car_class_id is included then the standings are for the car in that car class, otherwise they are for the car across car classes.</param>
+        /// <returns></returns>
+        Task<LeagueSeasonStandingsResult> GetLeagueSeasonStandings(int leagueId, int seasonId, int? carClassId = null, int? carId = null);
+
+        /// <summary>
+        /// Get a member's data.
+        /// </summary>
+        /// <param name="customerIds"></param>
+        /// <param name="includeLicenses"></param>
+        /// <returns></returns>
+        Task<MembersResult> GetMember(IEnumerable<int> customerIds, bool includeLicenses);
+
+        /// <summary>
+        /// Lookup a member's awards.
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <returns></returns>
+        Task<List<MemberAward>> GetMemberAwards(int? customerId = null);
+
+        /// <summary>
+        /// Get a member's chart data.
+        /// </summary>
+        /// <param name="categoryId">1 - Oval; 2 - Road; 3 - Dirt oval; 4 - Dirt road</param>
+        /// <param name="chartType">"1 - iRating; 2 - TT Rating; 3 - License/SR</param>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <returns></returns>
+        Task<MemberChartData> GetMemberChartData(int categoryId, int chartType, int? customerId = null);
+
+        /// <summary>
+        /// Get Member Info (Always the authenticated member.)
+        /// </summary>
+        /// <returns></returns>
+        Task<MemberInfo> GetMemberInfo();
+
+        /// <summary>
+        /// Get Member Participation Credits (Always the authenticated member.)
+        /// </summary>
+        /// <returns></returns>
+        Task<List<MemberParticipationCredits>> GetMemberParticipationCredits();
+
+        /// <summary>
+        /// Get Member Profile
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <returns></returns>
+        Task<MemberProfile> GetMemberProfile(int? customerId = null);
+
+        /// <summary>
+        /// Get Points System By League Id and (optionally) Season Id
+        /// </summary>
+        /// <param name="leagueId"></param>
+        /// <param name="seasonId">If included and the season is using custom points (points_system_id:2) then the custom points option is included in the returned list. Otherwise the custom points option is not returned.</param>
+        /// <returns></returns>
+        Task<PointsSystemResponse> GetPointsSystems(int leagueId, int? seasonId = null);
+
+        /// <summary>
+        /// Get Member Recent Results <para />
+        /// Get the results of a subsession, if authorized to view them. series_logo image paths are relative to https://images-static.iracing.com/img/logos/series/
+        /// </summary>
+        /// <param name="subSessionId"></param>
+        /// <param name="includeLicenses"></param>
+        /// <returns></returns>
+        Task<SubSessionResults> GetResults(int subSessionId, bool? includeLicenses = null);
+
+        /// <summary>
+        /// Get Result Event Logs
+        /// </summary>
+        /// <param name="subSessionId"></param>
+        /// <param name="simSessionNumber">The main event is 0; the preceding event is -1, and so on.</param>
+        /// <returns></returns>
+        Task<ResultEventLogs> GetResultsEventLogs(int subSessionId, int simSessionNumber);
+
+        /// <summary>
+        /// Get Result LapChartData
+        /// </summary>
+        /// <param name="subSessionId"></param>
+        /// <param name="simSessionNumber">The main event is 0; the preceding event is -1, and so on.</param>
+        /// <returns></returns>
+        Task<ResultsLapChartData> GetResultsLapChartData(int subSessionId, int simSessionNumber);
+
+        /// <summary>
+        /// Get lap data for a subsession
+        /// </summary>
+        /// <param name="subSessionId"></param>
+        /// <param name="simSessionNumber">The main event is 0; the preceding event is -1, and so on.</param>
+        /// <param name="customerId">Required if the subsession was a single-driver event. Optional for team events. If omitted for a team event then the laps driven by all the team's drivers will be included.</param>
+        /// <param name="teamId">Required if the subsession was a team event.</param>
+        /// <returns></returns>
+        Task<ResultLapData> GetResultsLapData(int subSessionId, int simSessionNumber, int? customerId = null, int? teamId = null);
+
+        /// <summary>
+        /// Hosted and league sessions.  Maximum time frame of 90 days. Results split into one or more files with chunks of results. For scraping results the most effective approach is to keep track of the maximum end_time found during a search then make the subsequent call using that date/time as the finish_range_begin and skip any subsessions that are duplicated.  Results are ordered by subsessionid which is a proxy for start time. Requires one of: start_range_begin, finish_range_begin. Requires one of: cust_id, team_id, host_cust_id, session_name.
+        /// </summary>
+        /// <param name="startRangeBegin">Session start times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
+        /// <param name="startRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if start_range_begin is less than 90 days in the past.</param>
+        /// <param name="finishRangeBegin">Session finish times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
+        /// <param name="finishRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if finish_range_begin is less than 90 days in the past.</param>
+        /// <param name="custId">The participant's customer ID. Ignored if team_id is supplied.</param>
+        /// <param name="teamId">The team ID to search for. Takes priority over cust_id if both are supplied.</param>
+        /// <param name="hostCustId">The host's customer ID.</param>
+        /// <param name="sessionName">Part or all of the session's name.</param>
+        /// <param name="leagueId">Include only results for the league with this ID.</param>
+        /// <param name="leagueSeasonId">Include only results for the league season with this ID.</param>
+        /// <param name="carId">One of the cars used by the session.</param>
+        /// <param name="trackId">The ID of the track used by the session.</param>
+        /// <param name="categoryIds">Track categories to include in the search.  Defaults to all</param>
+        /// <returns></returns>
+        Task<ResultSearchHosted> GetResultsSearchHosted(DateTimeOffset? startRangeBegin = null, DateTimeOffset? startRangeEnd = null, DateTimeOffset? finishRangeBegin = null, DateTimeOffset? finishRangeEnd = null, int? custId = null, int? teamId = null, int? hostCustId = null, string? sessionName = null, int? leagueId = null, int? leagueSeasonId = null, int? carId = null, int? trackId = null, IEnumerable<int>? categoryIds = null);
+
+        /// <summary>
+        /// Official series.  Maximum time frame of 90 days. Results split into one or more files with chunks of results. For scraping results the most effective approach is to keep track of the maximum end_time found during a search then make the subsequent call using that date/time as the finish_range_begin and skip any subsessions that are duplicated.  Results are ordered by subsessionid which is a proxy for start time but groups together multiple splits of a series when multiple series launch sessions at the same time. Requires at least one of: season_year and season_quarter, start_range_begin, finish_range_begin.
+        /// </summary>
+        /// <param name="seasonYear">Required when using season_quarter.</param>
+        /// <param name="seasonQuarter">Required when using season_year.</param>
+        /// <param name="startRangeBegin">Session start times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
+        /// <param name="startRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if start_range_begin is less than 90 days in the past.</param>
+        /// <param name="finishRangeBegin">Session finish times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
+        /// <param name="finishRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if finish_range_begin is less than 90 days in the past.</param>
+        /// <param name="customerId">Include only sessions in which this customer participated. Ignored if team_id is supplied.</param>
+        /// <param name="teamId">Include only sessions in which this team participated. Takes priority over cust_id if both are supplied.</param>
+        /// <param name="seriesId">Include only sessions for series with this ID.</param>
+        /// <param name="raceWeekNum">Include only sessions with this race week number.</param>
+        /// <param name="officialOnly">If true, include only sessions earning championship points. Defaults to all.</param>
+        /// <param name="eventTypes">Types of events to include in the search. Defaults to all.</param>
+        /// <param name="categoryIds">License categories to include in the search.  Defaults to all.</param>
+        /// <returns></returns>
+        Task<ResultsSearchSeries> GetResultsSearchSeries(int? seasonYear = null, int? seasonQuarter = null, DateTimeOffset? startRangeBegin = null, DateTimeOffset? startRangeEnd = null, DateTimeOffset? finishRangeBegin = null, DateTimeOffset? finishRangeEnd = null, int? customerId = null, int? teamId = null, int? seriesId = null, int? raceWeekNum = null, bool? officialOnly = null, IEnumerable<int>? eventTypes = null, IEnumerable<int>? categoryIds = null);
+
+        /// <summary>
+        /// Get Season Results
+        /// </summary>
+        /// <param name="seasonId">Season Id (required)</param>
+        /// <param name="eventType">Retrict to one event type: 2 - Practice; 3 - Qualify; 4 - Time Trial; 5 - Race</param>
+        /// <param name="raceWeekNum">The first race week of a season is 0.</param>
+        /// <returns></returns>
+        Task<ResultsSeasonResults> GetResultsSeasonResults(int seasonId, int? eventType = null, int? raceWeekNum = null);
+
+        /// <summary>
+        /// Get Season List
+        /// </summary>
+        /// <param name="seasonYear">Required</param>
+        /// <param name="seasonQuarter">Required</param>
+        /// <returns></returns>
+        Task<SeasonListResult> GetSeasonList(int seasonYear, int seasonQuarter);
+
+        /// <summary>
+        /// Get Season Race Guide
+        /// </summary>
+        /// <param name="from">ISO-8601 offset format. Defaults to the current time. Include sessions with start times up to 3 hours after this time. Times in the past will be rewritten to the current time.</param>
+        /// <param name="includeEndAfterFrom">Include sessions which start before 'from' but end after.</param>
+        /// <returns></returns>
+        Task<SeasonRaceGuideResults> GetSeasonRaceGuide(DateTime? from = null, bool? includeEndAfterFrom = null);
+
+        /// <summary>
+        /// Get Season Spectator SubSessionIds
+        /// </summary>
+        /// <param name="eventTypes">Types of events to include in the search. Defaults to all.</param>
+        /// <returns></returns>
+        Task<SeasonSpectatorSubSessionIdsResult> GetSeasonSpectatorSubSessionIds(IEnumerable<int>? eventTypes = null);
+
+        /// <summary>
+        /// Get Series
+        /// </summary>
+        /// <returns></returns>
+        Task<List<SeriesResult>> GetSeries();
+
+        /// <summary>
+        /// Get Series Assetts (image paths are relative to https://images-static.iracing.com/)
+        /// </summary>
+        /// <returns>Dictionary where key is series id and value is series asset</returns>
+        Task<Dictionary<string, SeriesAsset>> GetSeriesAssets();
+
+        /// <summary>
+        /// Get all seasons for a series. Filter list by official:true for seasons with standings.
+        /// </summary>
+        /// <param name="seriesId">Series Id (required)</param>
+        /// <returns></returns>
+        Task<SeriesPastSeasonResult> GetSeriesPastSeasons(int seriesId);
+
+        /// <summary>
+        /// Get Series
+        /// </summary>
+        /// <param name="includeSeries"></param>
+        /// <returns></returns>
+        Task<List<SeriesSeasonsResult>> GetSeriesSeasons(bool? includeSeries = null);
+
+        /// <summary>
+        /// Get Series Stats
+        /// </summary>
+        /// <returns></returns>
+        Task<List<SeriesStats>> GetSeriesStats();
+
+        /// <summary>
+        /// Get Stats Member Bests
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <param name="carId">First call should exclude car_id; use cars_driven list in return for subsequent calls.</param>
+        /// <returns></returns>
+        Task<StatsMemberBests> GetStatsMemberBests(int? customerId = null, int? carId = null);
+
+        /// <summary>
+        /// Get Status Member Career
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <returns></returns>
+        Task<StatsMemberCareer> GetStatsMemberCareer(int? customerId = null);
+
+        /// <summary>
+        /// Get Stats Member Division (Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Always for the authenticated member.)
+        /// </summary>
+        /// <param name="seasonId">(Required)</param>
+        /// <param name="eventType">The event type code for the division type: 4 - Time Trial; 5 - Race (Required)</param>
+        /// <returns></returns>
+        Task<StatsMemberDivision> GetStatsMemberDivision(int seasonId, int eventType);
+
+        /// <summary>
+        /// Get Stats Member Event Results
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <param name="year">Season year; if not supplied the current calendar year (UTC) is used.</param>
+        /// <param name="seasonId">Season (quarter) within the year; if not supplied the recap will be fore the entire year.</param>
+        /// <returns></returns>
+        Task<StatsMemberRecapResult> GetStatsMemberRecap(int? customerId = null, int? year = null, int? seasonId = null);
+
+        /// <summary>
+        /// Get Stats Member Recent Races
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <returns></returns>
+        Task<StatsMemberRecentRacesResult> GetStatsMemberRecentRaces(int? customerId = null);
+
+        /// <summary>
+        /// Get Stats Member Results
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <returns></returns>
+        Task<StatsMemberSummaryResult> GetStatsMemberSummary(int? customerId = null);
+
+        /// <summary>
+        /// Get Stats Member Yearly
+        /// </summary>
+        /// <param name="customerId">Defaults to the authenticated member.</param>
+        /// <returns></returns>
+        Task<StatsMemberYearlyResult> GetStatsMemberYearly(int? customerId = null);
+
+        /// <summary>
+        /// Get Stats Season Driver Standings
+        /// </summary>
+        /// <param name="seasonId">Required.</param>
+        /// <param name="carClassId">Required.</param>
+        /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
+        /// <param name="raceWeekNum">The first race week of a season is 0.</param>
+        /// <returns></returns>
+        Task<StatsSeasonDriverStandingsResult> GetStatsSeasonDriverStandings(int seasonId, int carClassId, int? division = null, int? raceWeekNum = null);
+
+        /// <summary>
+        /// Get Stats Season Qualify Results
+        /// </summary>
+        /// <param name="seasonId">Required.</param>
+        /// <param name="carClassId">Required.</param>
+        /// <param name="raceWeekNum">The first race week of a season is 0. (Required)</param>
+        /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
+        /// <returns></returns>
+        Task<StatsSeasonQualifyResults> GetStatsSeasonQualifyResults(int seasonId, int carClassId, int raceWeekNum, int? division = null);
+
+        /// <summary>
+        /// Get Stats Season Supersession Results
+        /// </summary>
+        /// <param name="seasonId">Required.</param>
+        /// <param name="carClassId">Required.</param>
+        /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
+        /// <param name="raceWeekNum">The first race week of a season is 0.</param>
+        /// <returns></returns>
+        Task<StatsSeasonSuperSessionStandingsResult> GetStatsSeasonSuperSessionStandings(int seasonId, int carClassId, int? division = null, int? raceWeekNum = null);
+
+        /// <summary>
+        /// Get Stats Season Team Standings
+        /// </summary>
+        /// <param name="seasonId">Required.</param>
+        /// <param name="carClassId">Required.</param>
+        /// <param name="raceWeekNum">The first race week of a season is 0.</param>
+        /// <returns></returns>
+        Task<StatsSeasonTeamStandingsResult> GetStatsSeasonTeamStandings(int seasonId, int carClassId, int? raceWeekNum = null);
+
+        /// <summary>
+        /// Get Stats Season TT Results
+        /// </summary>
+        /// <param name="seasonId">Required.</param>
+        /// <param name="carClassId">Required.</param>
+        /// <param name="raceWeekNum">The first race week of a season is 0. (Required)</param>
+        /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
+        /// <returns></returns>
+        Task<StatsSeasonTtResults> GetStatsSeasonTtResults(int seasonId, int carClassId, int raceWeekNum, int? division = null);
+
+        /// <summary>
+        /// Get Stats Season TT Standings
+        /// </summary>
+        /// <param name="seasonId">Required.</param>
+        /// <param name="carClassId">Required.</param>
+        /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
+        /// <param name="raceWeekNum">The first race week of a season is 0.</param>
+        /// <returns></returns>
+        Task<StatsSeasonTtStandingsResult> GetStatsSeasonTtStandings(int seasonId, int carClassId, int? division = null, int? raceWeekNum = null);
+
+        /// <summary>
+        /// Get Stats World Record Results
+        /// </summary>
+        /// <param name="carId">Required.</param>
+        /// <param name="trackId">Required.</param>
+        /// <param name="seasonYear">Limit best times to a given year.</param>
+        /// <param name="seasonQuarter">Limit best times to a given quarter; only applicable when year is used.</param>
+        /// <returns></returns>
+        Task<StatsWorldRecordResults> GetStatsWorldRecordResults(int carId, int trackId, int? seasonYear = null, int? seasonQuarter = null);
+
+        /// <summary>
+        /// Get Team by Id
+        /// </summary>
+        /// <param name="teamId">Required.</param>
+        /// <param name="includeLicenses">For faster responses, only request when necessary.</param>
+        /// <returns></returns>
+        Task<TeamResult> GetTeam(int teamId, bool? includeLicenses = null);
+
+        /// <summary>
+        /// Get Time Attack Season Results
+        /// </summary>
+        /// <remarks>image paths are relative to https://images-static.iracing.com/</remarks>
+        /// <returns></returns>
+        Task<Dictionary<string, TrackDetailsResult>> GetTrackAssets();
+
+        /// <summary>
+        /// Get Tracks
+        /// </summary>
+        /// <remarks>image paths are relative to https://images-static.iracing.com/</remarks>
+        /// <returns></returns>
+        Task<List<TrackResult>> GetTracks();
+
+        /// <summary>
+        /// Lookup values of settings using a dictionary where key is the tag name and the value is an array of lookup values to be tagged.
+        /// </summary>
+        /// <param name="lookups"></param>
+        /// <example>
+        /// <code>
+        /// var lookups = new Dictionary%lt;string, string[]%gt;
+        /// {
+        ///     { "weather", new string[] { "weather_wind_speed_units", "weather_wind_speed_max", "weather_wind_speed_min" } },
+        ///     { "licenselevels", new string[] { "licenselevels" } }
+        /// };
+        /// var result = await api.Lookup(lookups);
+        /// </code>
+        /// </example>
+        /// <returns></returns>
+        Task<List<LookupResult>> Lookup(Dictionary<string, string[]> lookups);
+
+        /// <summary>
+        /// Lookup Countries
+        /// </summary>
+        /// <returns></returns>
+        Task<List<Country>> LookupCountries();
+
+        /// <summary>
+        /// Lookup Drivers
+        /// </summary>
+        /// <param name="searchTerm">Search Term (required)</param>
+        /// <param name="leagueId">League Id</param>
+        /// <returns></returns>
+        Task<List<Driver>> LookupDrivers(string searchTerm, int? leagueId = null);
+
+        /// <summary>
+        /// Lookup License Levels
+        /// </summary>
+        /// <returns></returns>
+        Task<List<LookupLicenseResult>> LookupLicenses();
+
+        /// <summary>
+        /// Search for leagues based on various criteria.
+        /// </summary>
+        /// <param name="search">Will search against league name, description, owner, and league ID.</param>
+        /// <param name="tag">One or more tags, comma-separated.</param>
+        /// <param name="restrictToMember">If true include only leagues for which customer is a member.</param>
+        /// <param name="restrictToRecruiting">If true include only leagues which are recruiting.</param>
+        /// <param name="restrictToFriends">If true include only leagues owned by a friend.</param>
+        /// <param name="restrictToWatched">If true include only leagues owned by a watched member.</param>
+        /// <param name="minimumRosterCount">If set include leagues with at least this number of members.</param>
+        /// <param name="maximumRosterCount">If set include leagues with no more than this number of members.</param>
+        /// <param name="lowerBound">First row of results to return.  Defaults to 1.</param>
+        /// <param name="upperBound">Last row of results to return. Defaults to lowerbound + 39.</param>
+        /// <param name="sort">One of relevance, leaguename, displayname, rostercount. displayname is owners's name. Defaults to relevance.</param>
+        /// <param name="order">One of asc or desc.  Defaults to asc.</param>
+        /// <returns></returns>
+        Task<LeagueResult> SearchLeagues(string? search = null, string? tag = null, bool? restrictToMember = null, bool? restrictToRecruiting = null, bool? restrictToFriends = null, bool? restrictToWatched = null, bool? minimumRosterCount = null, bool? maximumRosterCount = null, int? lowerBound = null, int? upperBound = null, LeagueSortValue? sort = null, SortOrder? order = null);
+    }
+}

--- a/Frenetik.iRacingApiWrapper/IIRacingApiService.cs
+++ b/Frenetik.iRacingApiWrapper/IIRacingApiService.cs
@@ -103,9 +103,9 @@ namespace Frenetik.iRacingApiWrapper
         /// <summary>
         /// Get LeagueMembership by Customer Id
         /// </summary>
-        /// <param name="customerId">If different from the authenticated member, the following resrictions apply: <para />
+        /// <param name="customerId">If different from the authenticated member, the following restrictions apply: <para />
         /// - Caller cannot be on requested customer's block list or an empty list will result;<para />
-        /// - Requested customer cannot have their online activity prefrence set to hidden or an empty list will result;<para />
+        /// - Requested customer cannot have their online activity preference set to hidden or an empty list will result;<para />
         /// - Only leagues for which the requested customer is an admin and the league roster is not private are returned.</param>
         /// <param name="includeLeague"></param>
         /// <returns></returns>
@@ -266,7 +266,7 @@ namespace Frenetik.iRacingApiWrapper
         /// Get Season Results
         /// </summary>
         /// <param name="seasonId">Season Id (required)</param>
-        /// <param name="eventType">Retrict to one event type: 2 - Practice; 3 - Qualify; 4 - Time Trial; 5 - Race</param>
+        /// <param name="eventType">Restrict to one event type: 2 - Practice; 3 - Qualify; 4 - Time Trial; 5 - Race</param>
         /// <param name="raceWeekNum">The first race week of a season is 0.</param>
         /// <returns></returns>
         Task<ResultsSeasonResults> GetResultsSeasonResults(int seasonId, int? eventType = null, int? raceWeekNum = null);
@@ -301,7 +301,7 @@ namespace Frenetik.iRacingApiWrapper
         Task<List<SeriesResult>> GetSeries();
 
         /// <summary>
-        /// Get Series Assetts (image paths are relative to https://images-static.iracing.com/)
+        /// Get Series Assets (image paths are relative to https://images-static.iracing.com/)
         /// </summary>
         /// <returns>Dictionary where key is series id and value is series asset</returns>
         Task<Dictionary<string, SeriesAsset>> GetSeriesAssets();

--- a/Frenetik.iRacingApiWrapper/IRacingApiService.cs
+++ b/Frenetik.iRacingApiWrapper/IRacingApiService.cs
@@ -16,12 +16,13 @@ namespace Frenetik.iRacingApiWrapper;
 /// <summary>
 /// iRacing API Wrapper
 /// </summary>
-public class IRacingApiService
+public class IRacingApiService : IIRacingApiService
 {
     private readonly IRacingDataSettings _settings;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<IRacingApiService> _logger;
     private readonly IAsyncPolicy<HttpResponseMessage> _retryPolicy;
+    private readonly string _httpClientName;
 
     private const string Iso8601DateFormat = "yyyy-MM-ddTHH:mmZ";
 
@@ -36,7 +37,8 @@ public class IRacingApiService
     /// <param name="httpClientFactory">HTTP client factory for creating clients per request</param>
     /// <param name="settings">iRacing API settings (optional - defaults to standard configuration if not provided)</param>
     /// <param name="logger">Logger instance</param>
-    public IRacingApiService(IHttpClientFactory httpClientFactory, IOptions<IRacingDataSettings> settings, ILogger<IRacingApiService> logger)
+    /// <param name="httpClientName">Optional HTTP client name (defaults to "IRacing" for backwards compatibility)</param>
+    public IRacingApiService(IHttpClientFactory httpClientFactory, IOptions<IRacingDataSettings> settings, ILogger<IRacingApiService> logger, string? httpClientName = null)
     {
         ArgumentNullException.ThrowIfNull(httpClientFactory);
         ArgumentNullException.ThrowIfNull(logger);
@@ -44,307 +46,115 @@ public class IRacingApiService
         _settings = settings.Value;
         _httpClientFactory = httpClientFactory;
         _logger = logger;
+        _httpClientName = httpClientName ?? HttpClientName;
         _retryPolicy = RetryPolicyBuilder.BuildPolicy(_settings.RetryPolicy, _logger);
     }
 
-    /// <summary>
-    /// Gets documentation for all available endpoints, including required and optional parameters.
-    /// Each endpoint is a dictionary with the key being the endpoint name and the value being a dictionary of the endpoint details.
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<Dictionary<string, Dictionary<string, EndpointDetails>>> GetDoc() => GetResources<Dictionary<string, Dictionary<string, EndpointDetails>>>("/doc", false);
 
-    /// <summary>
-    /// Get Category constants
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<IEnumerable<Constant>> GetConstantsCategories() => GetResources<IEnumerable<Constant>>("/constants/categories", false);
 
-    /// <summary>
-    /// Get Division constants
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<IEnumerable<Constant>> GetConstantsDivisions() => GetResources<IEnumerable<Constant>>("/constants/divisions", false);
 
-    /// <summary>
-    /// Get EventType constants
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<IEnumerable<Constant>> GetConstantsEventTypes() => GetResources<IEnumerable<Constant>>("/constants/event_types", false);
 
-    /// <summary>
-    /// Get car assets
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public async Task<IEnumerable<CarAsset>> GetCarAssets() => (await GetResources<Dictionary<string, CarAsset>>("/car/assets", true)).Values;
 
-    /// <summary>
-    /// Get cars
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<IEnumerable<Car>> GetCars() => GetResources<IEnumerable<Car>>("/car/get", true);
 
-    /// <summary>
-    /// Get car classes
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<IEnumerable<CarClass>> GetCarClasses() => GetResources<IEnumerable<CarClass>>("/carclass/get", true);
 
-    /// <summary>
-    /// Get hosted combined sessions
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SessionResult> GetHostedCombinedSessions() => GetResources<SessionResult>("/hosted/combined_sessions", true);
 
-    /// <summary>
-    /// Get hosted combined session by package id
-    /// </summary>
-    /// <param name="packageId"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SessionResult> GetHostedCombinedSession(int packageId) => GetResources<SessionResult>("/hosted/combined_sessions", true, new Dictionary<string, string> { { "package_Id", packageId.ToString() } });
 
-    /// <summary>
-    /// Get hosted sessions
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SessionResult> GetHostedSessions() => GetResources<SessionResult>("/hosted/sessions", true);
 
-    /// <summary>
-    /// Get Cust League Session Results
-    /// </summary>
-    /// <param name="mine">If true, return only sessions created by this user.</param>
-    /// <param name="packageId">If set, return only sessions using this car or track package ID.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SessionResult> GetCustLeagueSessionResults(bool mine = false, int? packageId = null) => GetResources<SessionResult>("/league/cust_league_sessions", true, BuildParameters(["mine", "package_id"], [mine, packageId]));
 
-    /// <summary>
-    /// Search for leagues based on various criteria.
-    /// </summary>
-    /// <param name="search">Will search against league name, description, owner, and league ID.</param>
-    /// <param name="tag">One or more tags, comma-separated.</param>
-    /// <param name="restrictToMember">If true include only leagues for which customer is a member.</param>
-    /// <param name="restrictToRecruiting">If true include only leagues which are recruiting.</param>
-    /// <param name="restrictToFriends">If true include only leagues owned by a friend.</param>
-    /// <param name="restrictToWatched">If true include only leagues owned by a watched member.</param>
-    /// <param name="minimumRosterCount">If set include leagues with at least this number of members.</param>
-    /// <param name="maximumRosterCount">If set include leagues with no more than this number of members.</param>
-    /// <param name="lowerBound">First row of results to return.  Defaults to 1.</param>
-    /// <param name="upperBound">Last row of results to return. Defaults to lowerbound + 39.</param>
-    /// <param name="sort">One of relevance, leaguename, displayname, rostercount. displayname is owners's name. Defaults to relevance.</param>
-    /// <param name="order">One of asc or desc.  Defaults to asc.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<LeagueResult> SearchLeagues(string? search = null, string? tag = null, bool? restrictToMember = null, bool? restrictToRecruiting = null, bool? restrictToFriends = null, bool? restrictToWatched = null,
         bool? minimumRosterCount = null, bool? maximumRosterCount = null, int? lowerBound = null, int? upperBound = null, LeagueSortValue? sort = null, SortOrder? order = null) =>
         GetResources<LeagueResult>("/league/directory", true, BuildParameters(["search", "tag", "restrict_to_member", "restrict_to_recruiting", "restrict_to_friends", "restrict_to_watched", "minimum_roster_count", "maximum_roster_count", "lowerbound", "upperbound", "sort", "order"],
             [search, tag, restrictToMember, restrictToRecruiting, restrictToFriends, restrictToWatched, minimumRosterCount, maximumRosterCount, lowerBound, upperBound, sort?.GetEnumMemberValue(), order?.GetEnumMemberValue()]));
 
-    /// <summary>
-    /// Get League by ID
-    /// </summary>
-    /// <param name="leagueId">League Id (required).</param>
-    /// <param name="includeLicenses">For faster responses, only request when necessary.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<LeagueDetailed> GetLeagueById(int leagueId, bool? includeLicenses = null) => GetResources<LeagueDetailed>($"/league/get", true, BuildParameters(["league_id", "include_licenses"], [leagueId, includeLicenses]));
 
-    /// <summary>
-    /// Get Points System By League Id and (optionally) Season Id
-    /// </summary>
-    /// <param name="leagueId"></param>
-    /// <param name="seasonId">If included and the season is using custom points (points_system_id:2) then the custom points option is included in the returned list. Otherwise the custom points option is not returned.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<PointsSystemResponse> GetPointsSystems(int leagueId, int? seasonId = null) => GetResources<PointsSystemResponse>($"/league/get_points_systems", true, BuildParameters(["league_id", "season_id"], [leagueId, seasonId]));
 
-    /// <summary>
-    /// Get LeagueMembership by Customer Id
-    /// </summary>
-    /// <param name="customerId">If different from the authenticated member, the following resrictions apply: <para />
-    /// - Caller cannot be on requested customer's block list or an empty list will result;<para />
-    /// - Requested customer cannot have their online activity prefrence set to hidden or an empty list will result;<para />
-    /// - Only leagues for which the requested customer is an admin and the league roster is not private are returned.</param>
-    /// <param name="includeLeague"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<LeagueMembership>> GetLeagueMembership(int customerId, bool? includeLeague = null) => GetResources<List<LeagueMembership>>($"/league/membership", true, BuildParameters(["cust_id", "include_league"], [customerId, includeLeague]));
 
-    /// <summary>
-    /// Returns a League's Seasons
-    /// </summary>
-    /// <param name="leagueId">League Id</param>
-    /// <param name="retired">If true include seasons which are no longer active.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<LeagueSeasonResult> GetLeagueSeasons(int leagueId, bool? retired = null) => GetResources<LeagueSeasonResult>($"/league/seasons", true, BuildParameters(["league_id", "return"], [leagueId, retired]));
 
-    /// <summary>
-    /// Get League Season Standings
-    /// </summary>
-    /// <param name="leagueId">League Id</param>
-    /// <param name="seasonId">Season Id</param>
-    /// <param name="carClassId"></param>
-    /// <param name="carId">If car_class_id is included then the standings are for the car in that car class, otherwise they are for the car across car classes.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<LeagueSeasonStandingsResult> GetLeagueSeasonStandings(int leagueId, int seasonId, int? carClassId = null, int? carId = null) => GetResources<LeagueSeasonStandingsResult>($"/league/season_standings", true, BuildParameters(["league_id", "season_id", "car_class_id", "car_id"], [leagueId, seasonId, carClassId, carId]));
 
-    /// <summary>
-    /// Get league season sessions
-    /// </summary>
-    /// <param name="leagueId">League Id</param>
-    /// <param name="seasonId">Season Id</param>
-    /// <param name="resultsOnly">If true include only sessions for which results are available.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<LeagueSeasonSessionsResult> GetLeagueSeasonsSessions(int leagueId, int seasonId, bool? resultsOnly = null) => GetResources<LeagueSeasonSessionsResult>($"/league/season_sessions", true, BuildParameters(["league_id", "season_id", "results_only"], [leagueId, seasonId, resultsOnly]));
 
-    /// <summary>
-    /// Lookup Countries
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<Country>> LookupCountries() => GetResources<List<Country>>("/lookup/countries", true);
 
-    /// <summary>
-    /// Lookup Drivers
-    /// </summary>
-    /// <param name="searchTerm">Search Term (required)</param>
-    /// <param name="leagueId">League Id</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<Driver>> LookupDrivers(string searchTerm, int? leagueId = null) => GetResources<List<Driver>>("/lookup/drivers", true, BuildParameters(["search_term", "league_id"], [searchTerm, leagueId]));
 
-    /// <summary>
-    /// Lookup values of settings using a dictionary where key is the tag name and the value is an array of lookup values to be tagged.
-    /// </summary>
-    /// <param name="lookups"></param>
-    /// <example> 
-    /// <code>
-    /// var lookups = new Dictionary%lt;string, string[]%gt;
-    /// {
-    ///     { "weather", new string[] { "weather_wind_speed_units", "weather_wind_speed_max", "weather_wind_speed_min" } },
-    ///     { "licenselevels", new string[] { "licenselevels" } }
-    /// };
-    /// var result = await api.Lookup(lookups);
-    /// </code>
-    /// </example>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<LookupResult>> Lookup(Dictionary<string, string[]> lookups) => GetResources<List<LookupResult>>("/lookup/get", true, lookups.SelectMany(kvp => kvp.Value.Select(v => new KeyValuePair<string, string>(kvp.Key, v))));
 
-    /// <summary>
-    /// Lookup License Levels
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<LookupLicenseResult>> LookupLicenses() => GetResources<List<LookupLicenseResult>>("/lookup/licenses", true);
 
-    /// <summary>
-    /// Lookup a member's awards.
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<MemberAward>> GetMemberAwards(int? customerId = null) => GetResources<List<MemberAward>>($"/member/awards", true, BuildParameters(["cust_id"], [customerId]));
 
-    /// <summary>
-    /// Get a member's chart data.
-    /// </summary>
-    /// <param name="categoryId">1 - Oval; 2 - Road; 3 - Dirt oval; 4 - Dirt road</param>
-    /// <param name="chartType">"1 - iRating; 2 - TT Rating; 3 - License/SR</param>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<MemberChartData> GetMemberChartData(int categoryId, int chartType, int? customerId = null) => GetResources<MemberChartData>($"/member/chart_data", true, BuildParameters(["category_id", "chart_type", "cust_id"], [categoryId, chartType, customerId]));
 
-    /// <summary>
-    /// Get a member's data.
-    /// </summary>
-    /// <param name="customerIds"></param>
-    /// <param name="includeLicenses"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<MembersResult> GetMember(IEnumerable<int> customerIds, bool includeLicenses) => GetResources<MembersResult>($"/member/get", true, BuildParameters(["cust_ids", "include_licenses"], [CreateCsv(customerIds), includeLicenses]));
 
-    /// <summary>
-    /// Get Member Info (Always the authenticated member.)
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<MemberInfo> GetMemberInfo() => GetResources<MemberInfo>("/member/info", true);
 
-    /// <summary>
-    /// Get Member Participation Credits (Always the authenticated member.)
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<MemberParticipationCredits>> GetMemberParticipationCredits() => GetResources<List<MemberParticipationCredits>>("member/participation_credits", true);
 
-    /// <summary>
-    /// Get Member Profile
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<MemberProfile> GetMemberProfile(int? customerId = null) => GetResources<MemberProfile>("/member/profile", true, BuildParameters(["cust_id"], [customerId]));
 
-    /// <summary>
-    /// Get Member Recent Results <para />
-    /// Get the results of a subsession, if authorized to view them. series_logo image paths are relative to https://images-static.iracing.com/img/logos/series/
-    /// </summary>
-    /// <param name="subSessionId"></param>
-    /// <param name="includeLicenses"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SubSessionResults> GetResults(int subSessionId, bool? includeLicenses = null) => GetResources<SubSessionResults>($"/results/get", true, BuildParameters(["subsession_id", "include_licenses"], [subSessionId, includeLicenses]));
 
-    /// <summary>
-    /// Get Result Event Logs
-    /// </summary>
-    /// <param name="subSessionId"></param>
-    /// <param name="simSessionNumber">The main event is 0; the preceding event is -1, and so on.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<ResultEventLogs> GetResultsEventLogs(int subSessionId, int simSessionNumber) => GetResources<ResultEventLogs>($"/results/event_log", true, BuildParameters(["subsession_id", "simsession_number"], [subSessionId, simSessionNumber]));
 
-    /// <summary>
-    /// Get Result LapChartData
-    /// </summary>
-    /// <param name="subSessionId"></param>
-    /// <param name="simSessionNumber">The main event is 0; the preceding event is -1, and so on.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<ResultsLapChartData> GetResultsLapChartData(int subSessionId, int simSessionNumber) => GetResources<ResultsLapChartData>($"/results/lap_chart_data", true, BuildParameters(["subsession_id", "simsession_number"], [subSessionId, simSessionNumber]));
 
-    /// <summary>
-    /// Get lap data for a subsession
-    /// </summary>
-    /// <param name="subSessionId"></param>
-    /// <param name="simSessionNumber">The main event is 0; the preceding event is -1, and so on.</param>
-    /// <param name="customerId">Required if the subsession was a single-driver event. Optional for team events. If omitted for a team event then the laps driven by all the team's drivers will be included.</param>
-    /// <param name="teamId">Required if the subsession was a team event.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<ResultLapData> GetResultsLapData(int subSessionId, int simSessionNumber, int? customerId = null, int? teamId = null) => GetResources<ResultLapData>($"/results/lap_data", true, BuildParameters(["subsession_id", "simsession_number", "cust_id", "team_id"], [subSessionId, simSessionNumber, customerId, teamId]));
 
-    /// <summary>
-    /// Hosted and league sessions.  Maximum time frame of 90 days. Results split into one or more files with chunks of results. For scraping results the most effective approach is to keep track of the maximum end_time found during a search then make the subsequent call using that date/time as the finish_range_begin and skip any subsessions that are duplicated.  Results are ordered by subsessionid which is a proxy for start time. Requires one of: start_range_begin, finish_range_begin. Requires one of: cust_id, team_id, host_cust_id, session_name.
-    /// </summary>
-    /// <param name="startRangeBegin">Session start times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
-    /// <param name="startRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if start_range_begin is less than 90 days in the past.</param>
-    /// <param name="finishRangeBegin">Session finish times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
-    /// <param name="finishRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if finish_range_begin is less than 90 days in the past.</param>
-    /// <param name="custId">The participant's customer ID. Ignored if team_id is supplied.</param>
-    /// <param name="teamId">The team ID to search for. Takes priority over cust_id if both are supplied.</param>
-    /// <param name="hostCustId">The host's customer ID.</param>
-    /// <param name="sessionName">Part or all of the session's name.</param>
-    /// <param name="leagueId">Include only results for the league with this ID.</param>
-    /// <param name="leagueSeasonId">Include only results for the league season with this ID.</param>
-    /// <param name="carId">One of the cars used by the session.</param>
-    /// <param name="trackId">The ID of the track used by the session.</param>
-    /// <param name="categoryIds">Track categories to include in the search.  Defaults to all</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<ResultSearchHosted> GetResultsSearchHosted(DateTimeOffset? startRangeBegin = null, DateTimeOffset? startRangeEnd = null, DateTimeOffset? finishRangeBegin = null, DateTimeOffset? finishRangeEnd = null, int? custId = null, int? teamId = null, int? hostCustId = null, string? sessionName = null, int? leagueId = null, int? leagueSeasonId = null, int? carId = null, int? trackId = null, IEnumerable<int>? categoryIds = null) =>
         GetResources<ResultSearchHosted>("/results/search_hosted", false, BuildParameters(["start_range_begin", "start_range_end", "finish_range_begin", "finish_range_end", "cust_id", "team_id", "host_cust_id", "session_name", "league_id", "league_season_id", "car_id", "track_id", "category_ids"],
                        [startRangeBegin?.ToString(Iso8601DateFormat, CultureInfo.InvariantCulture), startRangeEnd?.ToString(Iso8601DateFormat, CultureInfo.InvariantCulture), finishRangeBegin?.ToString(Iso8601DateFormat, CultureInfo.InvariantCulture), finishRangeEnd?.ToString(Iso8601DateFormat, CultureInfo.InvariantCulture), custId, teamId, hostCustId, sessionName, leagueId, leagueSeasonId, carId, trackId, CreateCsv(categoryIds)]));
 
-    /// <summary>
-    /// Official series.  Maximum time frame of 90 days. Results split into one or more files with chunks of results. For scraping results the most effective approach is to keep track of the maximum end_time found during a search then make the subsequent call using that date/time as the finish_range_begin and skip any subsessions that are duplicated.  Results are ordered by subsessionid which is a proxy for start time but groups together multiple splits of a series when multiple series launch sessions at the same time. Requires at least one of: season_year and season_quarter, start_range_begin, finish_range_begin.
-    /// </summary>
-    /// <param name="seasonYear">Required when using season_quarter.</param>
-    /// <param name="seasonQuarter">Required when using season_year.</param>
-    /// <param name="startRangeBegin">Session start times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
-    /// <param name="startRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if start_range_begin is less than 90 days in the past.</param>
-    /// <param name="finishRangeBegin">Session finish times. ISO-8601 UTC time zero offset: "2022-04-01T15:45Z".</param>
-    /// <param name="finishRangeEnd">ISO-8601 UTC time zero offset: "2022-04-01T15:45Z". Exclusive. May be omitted if finish_range_begin is less than 90 days in the past.</param>
-    /// <param name="customerId">Include only sessions in which this customer participated. Ignored if team_id is supplied.</param>
-    /// <param name="teamId">Include only sessions in which this team participated. Takes priority over cust_id if both are supplied.</param>
-    /// <param name="seriesId">Include only sessions for series with this ID.</param>
-    /// <param name="raceWeekNum">Include only sessions with this race week number.</param>
-    /// <param name="officialOnly">If true, include only sessions earning championship points. Defaults to all.</param>
-    /// <param name="eventTypes">Types of events to include in the search. Defaults to all.</param>
-    /// <param name="categoryIds">License categories to include in the search.  Defaults to all.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<ResultsSearchSeries> GetResultsSearchSeries(int? seasonYear = null, int? seasonQuarter = null, DateTimeOffset? startRangeBegin = null, DateTimeOffset? startRangeEnd = null, DateTimeOffset? finishRangeBegin = null, DateTimeOffset? finishRangeEnd = null, int? customerId = null, int? teamId = null, int? seriesId = null, int? raceWeekNum = null, bool? officialOnly = null, IEnumerable<int>? eventTypes = null, IEnumerable<int>? categoryIds = null) =>
         GetResources<ResultsSearchSeries>("/results/search_series", false, BuildParameters(["season_year", "season_quarter", "start_range_begin", "start_range_end", "finish_range_begin", "finish_range_end", "cust_id", "team_id", "series_id", "race_week_num", "official_only", "event_types", "category_ids"],
             [
@@ -363,243 +173,102 @@ public class IRacingApiService
                 CreateCsv(categoryIds)
             ]));
 
-    /// <summary>
-    /// Get Season Results
-    /// </summary>
-    /// <param name="seasonId">Season Id (required)</param>
-    /// <param name="eventType">Retrict to one event type: 2 - Practice; 3 - Qualify; 4 - Time Trial; 5 - Race</param>
-    /// <param name="raceWeekNum">The first race week of a season is 0.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<ResultsSeasonResults> GetResultsSeasonResults(int seasonId, int? eventType = null, int? raceWeekNum = null) =>
         GetResources<ResultsSeasonResults>("/results/season_results", true, BuildParameters(["season_id", "event_type", "race_week_num"], [seasonId, eventType, raceWeekNum]));
 
 
-    /// <summary>
-    /// Get Season List
-    /// </summary>
-    /// <param name="seasonYear">Required</param>
-    /// <param name="seasonQuarter">Required</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SeasonListResult> GetSeasonList(int seasonYear, int seasonQuarter) =>
         GetResources<SeasonListResult>("/season/list", true, BuildParameters(["season_year", "season_quarter"], [seasonYear, seasonQuarter]));
 
-    /// <summary>
-    /// Get Season Race Guide
-    /// </summary>
-    /// <param name="from">ISO-8601 offset format. Defaults to the current time. Include sessions with start times up to 3 hours after this time. Times in the past will be rewritten to the current time.</param>
-    /// <param name="includeEndAfterFrom">Include sessions which start before 'from' but end after.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SeasonRaceGuideResults> GetSeasonRaceGuide(DateTime? from = null, bool? includeEndAfterFrom = null) =>
         GetResources<SeasonRaceGuideResults>("season/race_guide", true, BuildParameters(["from", "include_end_after_from"], [from?.ToString(Iso8601DateFormat, CultureInfo.InvariantCulture), includeEndAfterFrom]));
 
-    /// <summary>
-    /// Get Season Spectator SubSessionIds
-    /// </summary>
-    /// <param name="eventTypes">Types of events to include in the search. Defaults to all.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SeasonSpectatorSubSessionIdsResult> GetSeasonSpectatorSubSessionIds(IEnumerable<int>? eventTypes = null) =>
         GetResources<SeasonSpectatorSubSessionIdsResult>("/season/spectator_subsessionids", true, BuildParameters(["event_types"], [CreateCsv(eventTypes)]));
 
-    /// <summary>
-    /// Get Series Assetts (image paths are relative to https://images-static.iracing.com/)
-    /// </summary>
-    /// <returns>Dictionary where key is series id and value is series asset</returns>
+    /// <inheritdoc />
     public Task<Dictionary<string, SeriesAsset>> GetSeriesAssets() => GetResources<Dictionary<string, SeriesAsset>>("/series/assets", true);
 
-    /// <summary>
-    /// Get Series
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<SeriesResult>> GetSeries() => GetResources<List<SeriesResult>>("/series/get", true);
 
-    /// <summary>
-    /// Get all seasons for a series. Filter list by official:true for seasons with standings.
-    /// </summary>
-    /// <param name="seriesId">Series Id (required)</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<SeriesPastSeasonResult> GetSeriesPastSeasons(int seriesId) => GetResources<SeriesPastSeasonResult>($"/series/past_seasons", true, BuildParameters(["series_id"], [seriesId]));
 
-    /// <summary>
-    /// Get Series
-    /// </summary>
-    /// <param name="includeSeries"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<SeriesSeasonsResult>> GetSeriesSeasons(bool? includeSeries = null) => GetResources<List<SeriesSeasonsResult>>("/series/seasons", true, BuildParameters(["include_series"], [includeSeries]));
 
-    /// <summary>
-    /// Get Series Stats
-    /// </summary>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<SeriesStats>> GetSeriesStats() => GetResources<List<SeriesStats>>("/series/stats_series", true);
 
-    /// <summary>
-    /// Get Stats Member Bests
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <param name="carId">First call should exclude car_id; use cars_driven list in return for subsequent calls.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsMemberBests> GetStatsMemberBests(int? customerId = null, int? carId = null) => GetResources<StatsMemberBests>("/stats/member_bests", true, BuildParameters(["cust_id", "car_id"], [customerId, carId]));
 
-    /// <summary>
-    /// Get Status Member Career
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsMemberCareer> GetStatsMemberCareer(int? customerId = null) => GetResources<StatsMemberCareer>("/stats/member_career", true, BuildParameters(["cust_id"], [customerId]));
 
-    /// <summary>
-    /// Get Stats Member Division (Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Always for the authenticated member.)
-    /// </summary>
-    /// <param name="seasonId">(Required)</param>
-    /// <param name="eventType">The event type code for the division type: 4 - Time Trial; 5 - Race (Required)</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsMemberDivision> GetStatsMemberDivision(int seasonId, int eventType) => GetResources<StatsMemberDivision>("/stats/member_division", true, BuildParameters(["season_id", "event_type"], [seasonId, eventType]));
 
-    /// <summary>
-    /// Get Stats Member Event Results
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <param name="year">Season year; if not supplied the current calendar year (UTC) is used.</param>
-    /// <param name="seasonId">Season (quarter) within the year; if not supplied the recap will be fore the entire year.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsMemberRecapResult> GetStatsMemberRecap(int? customerId = null, int? year = null, int? seasonId = null) => GetResources<StatsMemberRecapResult>("/stats/member_recap", true, BuildParameters(["cust_id", "year", "season_id"], [customerId, year, seasonId]));
 
-    /// <summary>
-    /// Get Stats Member Recent Races
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsMemberRecentRacesResult> GetStatsMemberRecentRaces(int? customerId = null) => GetResources<StatsMemberRecentRacesResult>("/stats/member_recent_races", true, BuildParameters(["cust_id"], [customerId]));
 
-    /// <summary>
-    /// Get Stats Member Results
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsMemberSummaryResult> GetStatsMemberSummary(int? customerId = null) => GetResources<StatsMemberSummaryResult>("/stats/member_summary", true, BuildParameters(["cust_id"], [customerId]));
 
-    /// <summary>
-    /// Get Stats Member Yearly
-    /// </summary>
-    /// <param name="customerId">Defaults to the authenticated member.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsMemberYearlyResult> GetStatsMemberYearly(int? customerId = null) => GetResources<StatsMemberYearlyResult>("/stats/member_yearly", true, BuildParameters(["cust_id"], [customerId]));
 
-    /// <summary>
-    /// Get Stats Season Driver Standings
-    /// </summary>
-    /// <param name="seasonId">Required.</param>
-    /// <param name="carClassId">Required.</param>
-    /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
-    /// <param name="raceWeekNum">The first race week of a season is 0.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsSeasonDriverStandingsResult> GetStatsSeasonDriverStandings(int seasonId, int carClassId, int? division = null, int? raceWeekNum = null) =>
         GetResources<StatsSeasonDriverStandingsResult>("/stats/season_driver_standings", true, BuildParameters(["season_id", "car_class_id", "division", "race_week_num"], [seasonId, carClassId, division, raceWeekNum]));
 
-    /// <summary>
-    /// Get Stats Season Supersession Results
-    /// </summary>
-    /// <param name="seasonId">Required.</param>
-    /// <param name="carClassId">Required.</param>
-    /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
-    /// <param name="raceWeekNum">The first race week of a season is 0.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsSeasonSuperSessionStandingsResult> GetStatsSeasonSuperSessionStandings(int seasonId, int carClassId, int? division = null, int? raceWeekNum = null) =>
         GetResources<StatsSeasonSuperSessionStandingsResult>("/stats/season_supersession_standings", true, BuildParameters(["season_id", "car_class_id", "division", "race_week_num"], [seasonId, carClassId, division, raceWeekNum]));
 
-    /// <summary>
-    /// Get Stats Season Team Standings
-    /// </summary>
-    /// <param name="seasonId">Required.</param>
-    /// <param name="carClassId">Required.</param>
-    /// <param name="raceWeekNum">The first race week of a season is 0.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsSeasonTeamStandingsResult> GetStatsSeasonTeamStandings(int seasonId, int carClassId, int? raceWeekNum = null) =>
         GetResources<StatsSeasonTeamStandingsResult>("/stats/season_team_standings", true, BuildParameters(["season_id", "car_class_id", "race_week_num"], [seasonId, carClassId, raceWeekNum]));
 
-    /// <summary>
-    /// Get Stats Season TT Standings
-    /// </summary>
-    /// <param name="seasonId">Required.</param>
-    /// <param name="carClassId">Required.</param>
-    /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
-    /// <param name="raceWeekNum">The first race week of a season is 0.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsSeasonTtStandingsResult> GetStatsSeasonTtStandings(int seasonId, int carClassId, int? division = null, int? raceWeekNum = null) =>
         GetResources<StatsSeasonTtStandingsResult>("/stats/season_tt_standings", true, BuildParameters(["season_id", "car_class_id", "division", "race_week_num"], [seasonId, carClassId, division, raceWeekNum]));
 
-    /// <summary>
-    /// Get Stats Season TT Results
-    /// </summary>
-    /// <param name="seasonId">Required.</param>
-    /// <param name="carClassId">Required.</param>
-    /// <param name="raceWeekNum">The first race week of a season is 0. (Required)</param>
-    /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsSeasonTtResults> GetStatsSeasonTtResults(int seasonId, int carClassId, int raceWeekNum, int? division = null) =>
         GetResources<StatsSeasonTtResults>("/stats/season_tt_results", true, BuildParameters(["season_id", "car_class_id", "race_week_num", "division"], [seasonId, carClassId, raceWeekNum, division]));
 
-    /// <summary>
-    /// Get Stats World Record Results
-    /// </summary>
-    /// <param name="carId">Required.</param>
-    /// <param name="trackId">Required.</param>
-    /// <param name="seasonYear">Limit best times to a given year.</param>
-    /// <param name="seasonQuarter">Limit best times to a given quarter; only applicable when year is used.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsWorldRecordResults> GetStatsWorldRecordResults(int carId, int trackId, int? seasonYear = null, int? seasonQuarter = null) =>
         GetResources<StatsWorldRecordResults>("/stats/world_records", true, BuildParameters(["car_id", "track_id", "season_year", "season_quarter"], [carId, trackId, seasonYear, seasonQuarter]));
 
-    /// <summary>
-    /// Get Stats Season Qualify Results
-    /// </summary>
-    /// <param name="seasonId">Required.</param>
-    /// <param name="carClassId">Required.</param>
-    /// <param name="raceWeekNum">The first race week of a season is 0. (Required)</param>
-    /// <param name="division">Divisions are 0-based: 0 is Division 1, 10 is Rookie. See /data/constants/divisons for more information. Defaults to all.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<StatsSeasonQualifyResults> GetStatsSeasonQualifyResults(int seasonId, int carClassId, int raceWeekNum, int? division = null) =>
         GetResources<StatsSeasonQualifyResults>("/stats/season_qualify_results", true, BuildParameters(["season_id", "car_class_id", "race_week_num", "division"], [seasonId, carClassId, raceWeekNum, division]));
 
-    /// <summary>
-    /// Get Team by Id
-    /// </summary>
-    /// <param name="teamId">Required.</param>
-    /// <param name="includeLicenses">For faster responses, only request when necessary.</param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<TeamResult> GetTeam(int teamId, bool? includeLicenses = null) => GetResources<TeamResult>($"/team/get", true, BuildParameters(["team_id", "include_licenses"], [teamId, includeLicenses]));
 
     //TODO: Complete /data/time_attack/member_season_results
 
-    /// <summary>
-    /// Get Time Attack Season Results
-    /// </summary>
-    /// <remarks>image paths are relative to https://images-static.iracing.com/</remarks>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<Dictionary<string, TrackDetailsResult>> GetTrackAssets() => GetResources<Dictionary<string, TrackDetailsResult>>("/track/assets", true);
 
-    /// <summary>
-    /// Get Tracks
-    /// </summary>
-    /// <remarks>image paths are relative to https://images-static.iracing.com/</remarks>
-    /// <returns></returns>
+    /// <inheritdoc />
     public Task<List<TrackResult>> GetTracks() => GetResources<List<TrackResult>>("/track/get", true);
 
-    /// <summary>
-    /// Some responses have a chunk_info property which contains a base_download_url and a list of chunk_file_names.  This method will retrieve the chunked data and return it as a list of lists.
-    /// </summary>
-    /// <typeparam name="T">Chunk Info's response data type</typeparam>
-    /// <param name="chunkedObject"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public async Task<List<T>> GetChunkInfoData<T>(IChunkInfo<T> chunkedObject) where T : class => CompressLists(await GetAssets<List<T>>(chunkedObject.ChunkInfo.BaseDownloadUrl, chunkedObject.ChunkInfo.ChunkFileNames));
 
-    /// <summary>
-    /// Some responses have a chunk_info property which contains a base_download_url and a list of chunk_file_names.  
-    /// This method will retrieve the chunked data and return it as an async enumerable of lists.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="chunkedObject"></param>
-    /// <returns></returns>
+    /// <inheritdoc />
     public async IAsyncEnumerable<List<T>> GetChunkInfoDataPageAsyncEnumerable<T>(IChunkInfo<T> chunkedObject) where T : class
     {
         foreach (var file in chunkedObject.ChunkInfo.ChunkFileNames)
@@ -657,7 +326,7 @@ public class IRacingApiService
 
     private async Task<T> GetFromApi<T>(string url)
     {
-        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        var httpClient = _httpClientFactory.CreateClient(_httpClientName);
 
         using var response = await _retryPolicy.ExecuteAsync(async () =>
         {

--- a/README.md
+++ b/README.md
@@ -3,58 +3,44 @@
 [![Version](https://img.shields.io/nuget/vpre/frenetik.iracingapiwrapper.svg)](https://www.nuget.org/packages/frenetik.iracingapiwrapper)
 [![Downloads](https://img.shields.io/nuget/dt/frenetik.iracingapiwrapper.svg)](https://www.nuget.org/packages/frenetik.iracingapiwrapper)
 
-## Overview
+A comprehensive C# wrapper for the iRacing API with built-in OAuth 2.0 authentication, automatic token refresh, retry policies, and support for both single-user and multi-user scenarios.
 
-This is a wrapper for the iRacing API service written in C#.  It is still early in development.  Use at your own risk and please report issues so they can be fixed.  Thanks!
+## Table of Contents
 
-## Submitting Issues
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Authentication Patterns](#authentication-patterns)
+- [Configuration](#configuration)
+- [Example Projects](#example-projects)
+- [Contributing](#contributing)
+- [Additional Resources](#additional-resources)
 
-Please report issues or suggestions via the [GitHub issue tracker](https://github.com/mikeruhl/iRacingApiWrapper/issues). Include steps to reproduce, expected behavior, and any relevant logs.
+## Features
 
-# IRacingApiService
+- ✅ **OAuth 2.0 Authentication** - Built-in support for iRacing's Password Limited grant flow
+- ✅ **Automatic Token Management** - Token caching, refresh, and expiration handling
+- ✅ **Multi-User Support** - Per-request token context for HTTP servers with multiple users
+- ✅ **Retry Policies** - Configurable retry logic for transient failures and rate limiting
+- ✅ **Secret Masking** - Automatic credential masking using iRacing's SHA-256 algorithm
+- ✅ **Type-Safe API** - Strongly-typed models for all iRacing API endpoints
+- ✅ **Thread-Safe** - Safe for concurrent use in multi-threaded applications
+- ✅ **Comprehensive Documentation** - Full XML documentation for IntelliSense support
+- ✅ **Mixed Authentication** - Support for both single-user and multi-user patterns simultaneously (.NET 8+)
 
-The `IRacingApiService` is a service for interfacing with the iRacing API. It uses authentication and logging mechanisms to provide a reliable and secure way to interact with iRacing data.
+## Prerequisites
 
-## Authentication
+- **.NET 8.0** or **.NET 10.0**
+- **iRacing OAuth Credentials** - Register your application at [iRacing OAuth](https://oauth.iracing.com)
 
-iRacing uses OAuth 2.0 bearer token authentication. This library provides a built-in `PasswordLimitedTokenProvider` for automated/headless applications, or you can implement your own custom token provider.
+## Installation
 
-### Option 1: Using PasswordLimitedTokenProvider (Recommended for Automated Apps)
-
-The `PasswordLimitedTokenProvider` is ideal for automated/headless applications that run on behalf of a registered user. This uses iRacing's Password Limited OAuth grant flow.
-
-> **Note:** This grant is limited to 3 registered users per client. Contact iRacing to register your client and users.
-
-#### 1. Configure OAuth Settings
-
-Store your OAuth credentials securely using user secrets (recommended) or appsettings.json:
-
-**Using User Secrets (Recommended for Development):**
 ```bash
-dotnet user-secrets set "OAuth:ClientId" "your_client_id"
-dotnet user-secrets set "OAuth:ClientSecret" "your_client_secret"
-dotnet user-secrets set "OAuth:Username" "your.email@example.com"
-dotnet user-secrets set "OAuth:Password" "your_password"
+dotnet add package Frenetik.iRacingApiWrapper
 ```
 
-**Or in appsettings.json:**
-
-> ⚠️ **WARNING**: Never commit credentials to source control! The example below is for reference only.
-> Always use User Secrets for development or secure configuration providers (Azure Key Vault, environment variables, etc.) for production.
-
-```json
-{
-  "OAuth": {
-    "ClientId": "your_client_id",
-    "ClientSecret": "your_client_secret",
-    "Username": "your.email@example.com",
-    "Password": "your_password",
-    "Scope": "iracing.auth"
-  }
-}
-```
-
-#### 2. Register Services
+## Quick Start
 
 ```csharp
 using Frenetik.iRacingApiWrapper;
@@ -62,271 +48,277 @@ using Frenetik.iRacingApiWrapper.Config;
 using Frenetik.iRacingApiWrapper.Service;
 using Microsoft.Extensions.DependencyInjection;
 
-public void ConfigureServices(IServiceCollection services)
+var services = new ServiceCollection();
+
+// Configure OAuth credentials
+services.Configure<PasswordLimitedTokenProviderSettings>(options =>
 {
-    // Configure OAuth settings
-    services.Configure<PasswordLimitedTokenProviderSettings>(
-        Configuration.GetSection("OAuth"));
+    options.ClientId = "your_client_id";
+    options.ClientSecret = "your_client_secret";
+    options.Username = "your.email@example.com";
+    options.Password = "your_password";
+});
 
-    // Register HTTP client with authentication handler
-    services.AddHttpClient(IRacingApiService.HttpClientName)
-        .SetHandlerLifetime(TimeSpan.FromMinutes(5))
-        .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
-
-    // Register services
-    services.AddTransient<BearerTokenDelegatingHandler>();
-    services.AddSingleton<ITokenProvider, PasswordLimitedTokenProvider>();
-    services.AddSingleton<IRacingApiService>();
-
-    services.AddLogging();
-}
-```
-
-#### 3. Use the Service
-
-```csharp
-public class RacingController : ControllerBase
-{
-    private readonly IRacingApiService _racingApiService;
-
-    public RacingController(IRacingApiService racingApiService)
-    {
-        _racingApiService = racingApiService;
-    }
-
-    public async Task<IActionResult> GetSeries()
-    {
-        var series = await _racingApiService.GetSeries();
-        return Ok(series);
-    }
-}
-```
-
-#### Features
-
-The `PasswordLimitedTokenProvider` automatically handles:
-- ✅ Secret masking using iRacing's SHA-256 algorithm
-- ✅ Token caching and expiration
-- ✅ Automatic token refresh using refresh tokens
-- ✅ Rate limit detection and error handling
-- ✅ Thread-safe token management
-
-### Option 2: Custom ITokenProvider Implementation
-
-For web applications with multiple users or custom OAuth flows, implement `ITokenProvider`:
-
-```csharp
-using Frenetik.iRacingApiWrapper.Service;
-
-public class MyTokenProvider : ITokenProvider
-{
-    private string? _cachedToken;
-    private DateTime _tokenExpiry;
-
-    public async Task<string> GetTokenAsync()
-    {
-        // Return cached token if still valid
-        if (!string.IsNullOrEmpty(_cachedToken) && DateTime.UtcNow < _tokenExpiry)
-        {
-            return _cachedToken;
-        }
-
-        // Implement your OAuth flow here
-        // For Authorization Code flow, handle redirects and token exchange
-        // For other flows, use your preferred OAuth library
-
-        return _cachedToken;
-    }
-}
-```
-
-Then register your custom provider:
-
-```csharp
-// Register HTTP client with authentication handler
+// Register services
 services.AddHttpClient(IRacingApiService.HttpClientName)
-    .SetHandlerLifetime(TimeSpan.FromMinutes(5))
     .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
 
-// Register services with custom token provider
 services.AddTransient<BearerTokenDelegatingHandler>();
-services.AddSingleton<ITokenProvider, MyTokenProvider>();
-services.AddSingleton<IRacingApiService>();
+services.AddSingleton<ITokenProvider, PasswordLimitedTokenProvider>();
+services.AddSingleton<IIRacingApiService, IRacingApiService>();
+services.AddLogging();
+
+// Use the API
+var provider = services.BuildServiceProvider();
+var api = provider.GetRequiredService<IIRacingApiService>();
+
+var series = await api.GetSeries();
+Console.WriteLine($"Found {series.Count()} series");
 ```
 
-### Option 3: Per-Request Bearer Tokens (Multi-User HTTP Server)
+> ⚠️ **SECURITY**: Never commit credentials to source control! Use User Secrets for development or secure configuration providers (Azure Key Vault, environment variables) for production.
 
-For HTTP servers handling multiple users with different tokens per request, use `ITokenContext`:
+## Authentication Patterns
+
+This library supports three authentication patterns. Choose based on your application architecture:
+
+### Pattern 1: Single-User (PasswordLimited)
+
+**Use Case:** Console apps, background jobs, or services that authenticate as one user.
+
+**Setup:**
+
+```bash
+# Store credentials securely using user secrets
+dotnet user-secrets set "OAuth:ClientId" "your_client_id"
+dotnet user-secrets set "OAuth:ClientSecret" "your_client_secret"
+dotnet user-secrets set "OAuth:Username" "your.email@example.com"
+dotnet user-secrets set "OAuth:Password" "your_password"
+```
 
 ```csharp
-using Frenetik.iRacingApiWrapper;
-using Frenetik.iRacingApiWrapper.Service;
-using Microsoft.Extensions.DependencyInjection;
+services.Configure<PasswordLimitedTokenProviderSettings>(
+    Configuration.GetSection("OAuth"));
 
-public void ConfigureServices(IServiceCollection services)
+services.AddHttpClient(IRacingApiService.HttpClientName)
+    .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
+
+services.AddTransient<BearerTokenDelegatingHandler>();
+services.AddSingleton<ITokenProvider, PasswordLimitedTokenProvider>();
+services.AddSingleton<IIRacingApiService, IRacingApiService>();
+```
+
+**Features:**
+- ✅ Automatic token acquisition and refresh
+- ✅ Secret masking using SHA-256
+- ✅ Rate limit handling
+
+**Full Example:** See [TestWrapper.PasswordLimited](TestWrapper.PasswordLimited/Program.cs)
+
+> **Note:** Password Limited grant is limited to 3 users per client. Contact iRacing to register.
+
+### Pattern 2: Multi-User (TokenContext)
+
+**Use Case:** Web APIs handling requests from multiple users with different tokens.
+
+**Setup:**
+
+```csharp
+services.AddSingleton<ITokenContext, TokenContext>();
+services.AddHttpClient(IRacingApiService.HttpClientName)
+    .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
+
+services.AddTransient<BearerTokenDelegatingHandler>();
+services.AddSingleton<ITokenProvider, NoOpTokenProvider>();
+services.AddSingleton<IIRacingApiService, IRacingApiService>();
+```
+
+**Usage:**
+
+```csharp
+public async Task<IActionResult> GetUserData(string userToken)
 {
-    // Register token context for per-request tokens
-    services.AddSingleton<ITokenContext, TokenContext>();
-
-    // Register HTTP client with authentication handler
-    services.AddHttpClient(IRacingApiService.HttpClientName)
-        .SetHandlerLifetime(TimeSpan.FromMinutes(5))
-        .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
-
-    // Register services
-    services.AddTransient<BearerTokenDelegatingHandler>();
-
-    // Use NoOpTokenProvider since tokens come from context
-    services.AddSingleton<ITokenProvider, NoOpTokenProvider>();
-
-    services.AddSingleton<IRacingApiService>();
-    services.AddLogging();
+    using (_tokenContext.SetToken(userToken))
+    {
+        var series = await _api.GetSeries(); // Uses userToken
+        return Ok(series);
+    }
+    // Token automatically cleared
 }
 ```
 
-Then use it in your controllers or services:
+**Features:**
+- ✅ Thread-safe per-request tokens using `AsyncLocal`
+- ✅ Automatic cleanup with `IDisposable`
+- ✅ Support for nested scopes
+
+**Important:** Always use `using` statements with `SetToken()` to ensure proper scoping.
+
+**Full Example:** See [TestWrapper.Bearer](TestWrapper.Bearer/Program.cs)
+
+### Pattern 3: Mixed Authentication (Keyed Services)
+
+**New in v4.2.0** - Requires .NET 8.0+
+
+**Use Case:** Applications that need BOTH single-user (background jobs) and multi-user (API requests) authentication.
+
+**Setup:**
 
 ```csharp
+// Register password-limited for background jobs
+services.AddHttpClient("IRacing.PasswordLimited")
+    .AddHttpMessageHandler(/* ... */);
+services.AddKeyedSingleton<ITokenProvider, PasswordLimitedTokenProvider>("PasswordLimited");
+services.AddKeyedSingleton<IIRacingApiService, IRacingApiService>("PasswordLimited", (sp, key) =>
+    new IRacingApiService(/* ... */, "IRacing.PasswordLimited"));
+
+// Register token-context for user requests
+services.AddHttpClient("IRacing.TokenContext")
+    .AddHttpMessageHandler(/* ... */);
+services.AddKeyedSingleton<ITokenContext, TokenContext>("TokenContext");
+services.AddKeyedSingleton<ITokenProvider, NoOpTokenProvider>("TokenContext");
+services.AddKeyedSingleton<IIRacingApiService, IRacingApiService>("TokenContext", (sp, key) =>
+    new IRacingApiService(/* ... */, "IRacing.TokenContext"));
+```
+
+**Usage:**
+
+```csharp
+// Background job - uses service credentials
+public class DataSyncService
+{
+    public DataSyncService([FromKeyedServices("PasswordLimited")] IIRacingApiService api) { }
+}
+
+// User controller - uses per-request tokens
 public class RacingController : ControllerBase
 {
-    private readonly IRacingApiService _racingApiService;
-    private readonly ITokenContext _tokenContext;
+    public RacingController(
+        [FromKeyedServices("TokenContext")] IIRacingApiService api,
+        [FromKeyedServices("TokenContext")] ITokenContext tokenContext) { }
+}
+```
 
-    public RacingController(IRacingApiService racingApiService, ITokenContext tokenContext)
+**Features:**
+- ✅ Complete isolation between strategies
+- ✅ No risk of token mixing
+- ✅ Each has own HttpClient pipeline
+
+**Full Example:** See [CHANGELOG.md](CHANGELOG.md#420) for complete setup code.
+
+### Custom Token Provider
+
+For custom OAuth flows (Authorization Code, Client Credentials, etc.), implement `ITokenProvider`:
+
+```csharp
+public class MyTokenProvider : ITokenProvider
+{
+    public async Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
     {
-        _racingApiService = racingApiService;
-        _tokenContext = tokenContext;
-    }
-
-    public async Task<IActionResult> GetUserSeries(string userBearerToken)
-    {
-        // Set token for this async execution flow
-        using (_tokenContext.SetToken(userBearerToken))
-        {
-            // All API calls within this scope will use the user's token
-            var series = await _racingApiService.GetSeries();
-            var cars = await _racingApiService.GetCars();
-
-            return Ok(new { series, cars });
-        }
-        // Token is automatically cleared when scope is disposed
+        // Implement your OAuth flow
+        return yourToken;
     }
 }
 ```
 
-**Benefits:**
-- ✅ Thread-safe and async-flow-safe using `AsyncLocal`
-- ✅ Different tokens for concurrent requests
-- ✅ Automatic token cleanup with `IDisposable` pattern
-- ✅ No modifications needed to `IRacingApiService`
+## Configuration
 
-### Additional Resources
+### Retry Policy
 
-- [iRacing OAuth Overview](https://oauth.iracing.com/oauth2/book/auth_overview.html)
-- [Password Limited Flow Documentation](https://oauth.iracing.com/oauth2/book/password_limited_flow.html)
-- [Authorization Code Flow](https://oauth.iracing.com/oauth2/book/authorize_endpoint.html)
-
-## Retry Policy Configuration
-
-Configure retry behavior for transient failures and rate limiting:
+Configure retry behavior for transient failures:
 
 ```csharp
-// Optional: Customize retry policies and base URL
 services.Configure<IRacingDataSettings>(options =>
 {
-    options.BaseUrl = "https://members-ng.iracing.com"; // Optional: override base URL
-    options.RetryPolicy.ServerErrorRetryCount = 3;
-    options.RetryPolicy.ServerErrorBaseDelayMs = 200;
-    options.RetryPolicy.RateLimitRetryCount = 3;
-    options.RetryPolicy.RateLimitDefaultDelaySeconds = 15;
-    options.RetryPolicy.ServiceUnavailableRetryCount = 0;
-    options.RetryPolicy.ServiceUnavailableDelaySeconds = 60;
+    options.RetryPolicy.ServerErrorRetryCount = 3;        // 5xx errors
+    options.RetryPolicy.RateLimitRetryCount = 3;          // 429 errors
+    options.RetryPolicy.ServiceUnavailableRetryCount = 0; // 503 errors (default: don't retry)
 });
 ```
 
-Or via appsettings.json:
+Or via `appsettings.json`:
 
 ```json
 {
     "IRacingDataSettings": {
-        "BaseUrl": "https://members-ng.iracing.com",
         "RetryPolicy": {
             "ServerErrorRetryCount": 3,
             "ServerErrorBaseDelayMs": 200,
             "RateLimitRetryCount": 3,
-            "RateLimitDefaultDelaySeconds": 15,
-            "ServiceUnavailableRetryCount": 0,
-            "ServiceUnavailableDelaySeconds": 60
+            "RateLimitDefaultDelaySeconds": 15
         }
-    }
-}
-```
-
-**Retry Policy Settings:**
-- **ServerErrorRetryCount**: Number of retries for 5xx errors (default: 3)
-- **ServerErrorBaseDelayMs**: Base delay for exponential backoff on 5xx errors (default: 200ms)
-- **RateLimitRetryCount**: Number of retries for 429 errors (default: 3)
-- **RateLimitDefaultDelaySeconds**: Default delay when rate limit reset header is not present (default: 15s)
-- **ServiceUnavailableRetryCount**: Number of retries for 503 errors (default: 0, since iRacing maintenance can last hours)
-- **ServiceUnavailableDelaySeconds**: Delay between 503 retries if enabled (default: 60s)
-
-## Exception Handling
-
-The wrapper throws `ErrorResponseException` for all API-related errors. The exception includes:
-- `ResultCode` (HttpStatusCode): HTTP status code from the API
-- `Error` (string): Error code or type
-- `Message` (string): Detailed error message
-
-```csharp
-try
-{
-    var results = await _racingApiService.GetResults(subSessionId, includeLicenses: true);
-}
-catch (ErrorResponseException ex)
-{
-    _logger.LogError("API error ({StatusCode}): {Error} - {Message}",
-        ex.ResultCode, ex.Error, ex.Message);
-
-    // Handle specific cases as needed
-    if (ex.ResultCode == HttpStatusCode.ServiceUnavailable)
-    {
-        // iRacing is down for maintenance
     }
 }
 ```
 
 **Automatic Retry Behavior:**
-- `401/403`: Not retried (authentication issues)
-- `429`: Retried with smart delay based on rate limit headers
+- `401/403`: Not retried (auth issues)
+- `429`: Retried with smart delay based on headers
 - `500-502`: Retried with exponential backoff
 - `503`: Not retried by default (maintenance can last hours)
 
+### Exception Handling
+
+All API errors throw `ErrorResponseException`:
+
+```csharp
+try
+{
+    var results = await _api.GetResults(subSessionId, includeLicenses: true);
+}
+catch (ErrorResponseException ex)
+{
+    _logger.LogError("API error ({StatusCode}): {Error} - {Message}",
+        ex.ResultCode, ex.Error, ex.Message);
+}
+```
+
 ## Example Projects
 
-This repository includes two example projects demonstrating different authentication scenarios:
+### [TestWrapper.PasswordLimited](TestWrapper.PasswordLimited/Program.cs)
 
-### TestWrapper.PasswordLimited
+Demonstrates **Pattern 1** - single-user authentication with automatic token refresh.
 
-Demonstrates using the `PasswordLimitedTokenProvider` for automated/headless applications. This example shows how to use OAuth 2.0 Password Limited grant flow with user secrets.
+**Run:**
+```bash
+cd TestWrapper.PasswordLimited
+dotnet user-secrets set "OAuth:ClientId" "your_client_id"
+dotnet user-secrets set "OAuth:ClientSecret" "your_client_secret"
+dotnet user-secrets set "OAuth:Username" "your.email@example.com"
+dotnet user-secrets set "OAuth:Password" "your_password"
+dotnet run
+```
 
-**Features:**
-- Automatic token acquisition and refresh
-- Configuration via user secrets or appsettings.json
+### [TestWrapper.Bearer](TestWrapper.Bearer/Program.cs)
 
-**Location:** `TestWrapper.PasswordLimited/Program.cs`
+Demonstrates **Pattern 2** - per-request tokens for multi-user scenarios.
 
-### TestWrapper.Bearer
+**Run:**
+1. Obtain a bearer token via [Authorization Code Flow](https://oauth.iracing.com/oauth2/book/authorization_code_flow.html)
+2. Set token in `userBearerToken` variable
+3. `dotnet run`
 
-Demonstrates using per-request bearer tokens with `ITokenContext` for multi-user HTTP server scenarios. This example shows how to use tokens obtained via OAuth 2.0 Authorization Code flow.
+## Contributing
 
-**Features:**
-- Per-request token management
-- Support for concurrent users with different tokens
-- Async-safe token context
+Contributions welcome! Please:
 
-**Location:** `TestWrapper.Bearer/Program.cs`
+1. **Report Issues**: Use the [GitHub issue tracker](https://github.com/mikeruhl/frenetik.iRacingApiWrapper/issues) with reproduction steps
+2. **Submit PRs**: Fork → feature branch → tests → PR
+3. **Follow Standards**: C# conventions, XML docs, unit tests, backward compatibility
 
-**Usage:**
-1. Obtain a bearer token using the [Authorization Code Flow](https://oauth.iracing.com/oauth2/book/authorization_code_flow.html)
-2. Set the token in the `userBearerToken` variable
-3. Run the example to see token context in action
+## Additional Resources
+
+- [iRacing OAuth Documentation](https://oauth.iracing.com/oauth2/book/auth_overview.html)
+- [Password Limited Flow](https://oauth.iracing.com/oauth2/book/password_limited_flow.html)
+- [Authorization Code Flow](https://oauth.iracing.com/oauth2/book/authorization_code_flow.html)
+- [iRacing API Docs](https://members-ng.iracing.com/data/doc)
+- [Changelog](CHANGELOG.md)
+- [NuGet Package](https://www.nuget.org/packages/frenetik.iracingapiwrapper)
+
+## License
+
+MIT License - see [LICENSE](LICENSE) file for details.
+
+---
+
+**Disclaimer**: This is an unofficial wrapper for the iRacing API. Not affiliated with or endorsed by iRacing.com Motorsport Simulations, LLC.


### PR DESCRIPTION
## Pull request overview

This PR adds support for configurable HTTP client names to `IRacingApiService`, enabling multiple service instances with different authentication strategies (e.g., password-limited for background jobs and per-request bearer tokens for user requests). The PR also extracts a new `IIRacingApiService` interface and replaces verbose XML documentation comments with `<inheritdoc />` tags.

**Changes:**
- Added optional `httpClientName` constructor parameter to `IRacingApiService` with backward-compatible default
- Introduced `IIRacingApiService` interface implemented by `IRacingApiService` 
- Replaced XML documentation comments in `IRacingApiService` with `<inheritdoc />` tags

### Reviewed changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 4 comments.

| File | Description |
| ---- | ----------- |
| IRacingApiService.cs | Added interface implementation, configurable HTTP client name field, updated constructor, and replaced documentation with inheritdoc tags |
| IIRacingApiService.cs | New interface containing all public API method signatures with comprehensive XML documentation |
| Frenetik.iRacingApiWrapper.csproj | Updated version from 2.0.0 to 4.2.0 |
| CHANGELOG.md | Added detailed 4.2.0 release notes with migration guide for mixed authentication patterns |





---

💡 <a href="/mikeruhl/frenetik.iRacingApiWrapper/new/main/.github/instructions?filename=*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.