### PR TITLE
split handlers

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -31,8 +31,17 @@ jobs:
       shell: pwsh
       run: |
         $tag = "${{ github.ref_name }}"
-        $version = $tag -replace '^v', ''
+        $version = $tag -replace '^v\.?', ''
         echo "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+        # Determine if this is a pre-release version
+        if ($version -match '-') {
+          echo "IS_PRERELEASE=true" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "Detected pre-release version: $version"
+        } else {
+          echo "IS_PRERELEASE=false" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "Detected stable release version: $version"
+        }
 
     - name: Clean workspace
       run: dotnet clean Frenetik.iRacingApiWrapper/Frenetik.iRacingApiWrapper.csproj --configuration Release
@@ -56,4 +65,9 @@ jobs:
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
-        dotnet nuget push ./nupkg/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key "$NUGET_API_KEY"
+        if [ "${{ env.IS_PRERELEASE }}" = "true" ]; then
+          echo "Publishing pre-release package version ${{ env.VERSION }} to NuGet..."
+        else
+          echo "Publishing stable release version ${{ env.VERSION }} to NuGet..."
+        fi
+        dotnet nuget push ./nupkg/*.nupkg --source "https://api.nuget.org/v3/index.json" --api-key "$NUGET_API_KEY" --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BearerTokenDelegatingHandler` - Split into two focused handlers for better separation of concerns
   - Use `PasswordLimitedTokenHandler` for single-user scenarios (Pattern 1)
   - Use `TokenContextHandler` for multi-user scenarios (Pattern 2)
-  - Will be marked as `[Obsolete]` in a future version
+  - Marked as `[Obsolete]` in this version
+  - Will be removed in future version
 - `NoOpTokenProvider` - No longer needed with `TokenContextHandler`
   - `TokenContextHandler` doesn't require an `ITokenProvider` dependency
-  - Will be removed in a future version
+  - Marked as obsolete in this version
+  - Will be removed in future version
 
 ### Changed
 - `IRacingApiService` now uses configurable `_httpClientName` field instead of hardcoded `HttpClientName` constant

--- a/Frenetik.iRacingApiWrapper.Tests/PasswordLimitedTokenHandlerTests.cs
+++ b/Frenetik.iRacingApiWrapper.Tests/PasswordLimitedTokenHandlerTests.cs
@@ -1,0 +1,291 @@
+using System.Net;
+using Frenetik.iRacingApiWrapper.Config;
+using Frenetik.iRacingApiWrapper.Service;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+
+namespace Frenetik.iRacingApiWrapper.Tests;
+
+public class PasswordLimitedTokenHandlerTests
+{
+    private readonly Mock<ITokenProvider> _tokenProviderMock;
+    private readonly IRacingDataSettings _settings;
+    private readonly Mock<HttpMessageHandler> _innerHandlerMock;
+
+    public PasswordLimitedTokenHandlerTests()
+    {
+        _tokenProviderMock = new Mock<ITokenProvider>();
+        _settings = new IRacingDataSettings
+        {
+            BaseUrl = "https://members-ng.iracing.com"
+        };
+        _innerHandlerMock = new Mock<HttpMessageHandler>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullTokenProvider_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new PasswordLimitedTokenHandler(null!, options));
+    }
+
+    [Fact]
+    public void Constructor_WithNullSettings_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new PasswordLimitedTokenHandler(_tokenProviderMock.Object, null!));
+    }
+
+    [Fact]
+    public void Constructor_WithValidParameters_DoesNotThrow()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+
+        // Act
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options);
+
+        // Assert
+        Assert.NotNull(handler);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithIRacingUrl_AddsAuthorizationHeader()
+    {
+        // Arrange
+        const string expectedToken = "test-bearer-token";
+        _tokenProviderMock.Setup(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedToken);
+
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using (await invoker.SendAsync(request, CancellationToken.None))
+        {
+            // Assert
+            Assert.NotNull(request.Headers.Authorization);
+            Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
+            Assert.Equal(expectedToken, request.Headers.Authorization.Parameter);
+            _tokenProviderMock.Verify(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithExternalUrl_DoesNotAddAuthorizationHeader()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://images-static.iracing.com/some-image.jpg");
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using (await invoker.SendAsync(request, CancellationToken.None))
+        {
+            // Assert
+            Assert.Null(request.Headers.Authorization);
+            _tokenProviderMock.Verify(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithS3Url_DoesNotAddAuthorizationHeader()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://scorpio-assets.s3.amazonaws.com/data.json");
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using (await invoker.SendAsync(request, CancellationToken.None))
+        {
+            // Assert
+            Assert.Null(request.Headers.Authorization);
+            _tokenProviderMock.Verify(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithEmptyToken_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _tokenProviderMock.Setup(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(string.Empty);
+
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        Assert.Contains("No bearer token available from ITokenProvider", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithNullToken_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _tokenProviderMock.Setup(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        Assert.Contains("No bearer token available from ITokenProvider", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithWhitespaceToken_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _tokenProviderMock.Setup(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("   ");
+
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        Assert.Contains("No bearer token available from ITokenProvider", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_PassesCancellationTokenToProvider()
+    {
+        // Arrange
+        const string expectedToken = "test-bearer-token";
+        var cts = new CancellationTokenSource();
+
+        _tokenProviderMock.Setup(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedToken);
+
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using (await invoker.SendAsync(request, cts.Token))
+        {
+            // Assert
+            _tokenProviderMock.Verify(tp => tp.GetTokenAsync(cts.Token), Times.Once);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithMultipleRequests_CallsProviderForEachRequest()
+    {
+        // Arrange
+        const string expectedToken = "test-bearer-token";
+        _tokenProviderMock.Setup(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedToken);
+
+        var options = Options.Create(_settings);
+        var handler = new PasswordLimitedTokenHandler(_tokenProviderMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using (await invoker.SendAsync(request1, CancellationToken.None)) { }
+
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/member/get");
+        using (await invoker.SendAsync(request2, CancellationToken.None)) { }
+
+        // Assert
+        _tokenProviderMock.Verify(tp => tp.GetTokenAsync(It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+}

--- a/Frenetik.iRacingApiWrapper.Tests/TokenContextHandlerTests.cs
+++ b/Frenetik.iRacingApiWrapper.Tests/TokenContextHandlerTests.cs
@@ -240,7 +240,7 @@ public class TokenContextHandlerTests
         // Act - First request
         _tokenContextMock.Setup(tc => tc.CurrentToken).Returns(token1);
         using var request1 = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
-        using (var response1 = await invoker.SendAsync(request1, CancellationToken.None))
+        using (_ = await invoker.SendAsync(request1, CancellationToken.None))
         {
             Assert.Equal(token1, request1.Headers.Authorization?.Parameter);
         }
@@ -248,7 +248,7 @@ public class TokenContextHandlerTests
         // Act - Second request with different token
         _tokenContextMock.Setup(tc => tc.CurrentToken).Returns(token2);
         using var request2 = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/member/get");
-        using (var response2 = await invoker.SendAsync(request2, CancellationToken.None))
+        using (_ = await invoker.SendAsync(request2, CancellationToken.None))
         {
             Assert.Equal(token2, request2.Headers.Authorization?.Parameter);
         }

--- a/Frenetik.iRacingApiWrapper.Tests/TokenContextHandlerTests.cs
+++ b/Frenetik.iRacingApiWrapper.Tests/TokenContextHandlerTests.cs
@@ -1,0 +1,313 @@
+using System.Net;
+using Frenetik.iRacingApiWrapper.Config;
+using Frenetik.iRacingApiWrapper.Service;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+
+namespace Frenetik.iRacingApiWrapper.Tests;
+
+public class TokenContextHandlerTests
+{
+    private readonly Mock<ITokenContext> _tokenContextMock;
+    private readonly IRacingDataSettings _settings;
+    private readonly Mock<HttpMessageHandler> _innerHandlerMock;
+
+    public TokenContextHandlerTests()
+    {
+        _tokenContextMock = new Mock<ITokenContext>();
+        _settings = new IRacingDataSettings
+        {
+            BaseUrl = "https://members-ng.iracing.com"
+        };
+        _innerHandlerMock = new Mock<HttpMessageHandler>();
+    }
+
+    [Fact]
+    public void Constructor_WithNullTokenContext_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new TokenContextHandler(null!, options));
+    }
+
+    [Fact]
+    public void Constructor_WithNullSettings_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new TokenContextHandler(_tokenContextMock.Object, null!));
+    }
+
+    [Fact]
+    public void Constructor_WithValidParameters_DoesNotThrow()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+
+        // Act
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options);
+
+        // Assert
+        Assert.NotNull(handler);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithIRacingUrl_AddsAuthorizationHeader()
+    {
+        // Arrange
+        const string expectedToken = "context-bearer-token";
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns(expectedToken);
+
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using (await invoker.SendAsync(request, CancellationToken.None))
+        {
+            // Assert
+            Assert.NotNull(request.Headers.Authorization);
+            Assert.Equal("Bearer", request.Headers.Authorization.Scheme);
+            Assert.Equal(expectedToken, request.Headers.Authorization.Parameter);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithExternalUrl_DoesNotAddAuthorizationHeader()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://images-static.iracing.com/some-image.jpg");
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using (await invoker.SendAsync(request, CancellationToken.None))
+        {
+            // Assert
+            Assert.Null(request.Headers.Authorization);
+            _tokenContextMock.Verify(tc => tc.CurrentToken, Times.Never);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithS3Url_DoesNotAddAuthorizationHeader()
+    {
+        // Arrange
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://scorpio-assets.s3.amazonaws.com/data.json");
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act
+        using (await invoker.SendAsync(request, CancellationToken.None))
+        {
+            // Assert
+            Assert.Null(request.Headers.Authorization);
+            _tokenContextMock.Verify(tc => tc.CurrentToken, Times.Never);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_WithEmptyToken_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns(string.Empty);
+
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        Assert.Contains("No bearer token available from ITokenContext", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithNullToken_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns((string?)null);
+
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        Assert.Contains("No bearer token available from ITokenContext", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithWhitespaceToken_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns("   ");
+
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        Assert.Contains("No bearer token available from ITokenContext", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithMultipleRequests_UsesContextTokenForEach()
+    {
+        // Arrange
+        const string token1 = "context-token-1";
+        const string token2 = "context-token-2";
+
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act - First request
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns(token1);
+        using var request1 = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using (var response1 = await invoker.SendAsync(request1, CancellationToken.None))
+        {
+            Assert.Equal(token1, request1.Headers.Authorization?.Parameter);
+        }
+
+        // Act - Second request with different token
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns(token2);
+        using var request2 = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/member/get");
+        using (var response2 = await invoker.SendAsync(request2, CancellationToken.None))
+        {
+            Assert.Equal(token2, request2.Headers.Authorization?.Parameter);
+        }
+    }
+
+    [Fact]
+    public async Task SendAsync_AccessesCurrentTokenPropertyOnlyForIRacingUrls()
+    {
+        // Arrange
+        const string expectedToken = "context-bearer-token";
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns(expectedToken);
+
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        _innerHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act - iRacing URL should access CurrentToken
+        using var iracingRequest = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using (await invoker.SendAsync(iracingRequest, CancellationToken.None)) { }
+
+        // Act - External URL should NOT access CurrentToken
+        using var externalRequest = new HttpRequestMessage(HttpMethod.Get, "https://external.com/data.json");
+        using (await invoker.SendAsync(externalRequest, CancellationToken.None)) { }
+
+        // Assert - CurrentToken accessed only once (for iRacing URL)
+        _tokenContextMock.Verify(tc => tc.CurrentToken, Times.Once);
+    }
+
+    [Fact]
+    public async Task SendAsync_ErrorMessageMentionsITokenContext()
+    {
+        // Arrange
+        _tokenContextMock.Setup(tc => tc.CurrentToken).Returns((string?)null);
+
+        var options = Options.Create(_settings);
+        var handler = new TokenContextHandler(_tokenContextMock.Object, options)
+        {
+            InnerHandler = _innerHandlerMock.Object
+        };
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://members-ng.iracing.com/data/series/get");
+        using var invoker = new HttpMessageInvoker(handler);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => invoker.SendAsync(request, CancellationToken.None));
+
+        // Verify the error message mentions ITokenContext.SetToken()
+        Assert.Contains("ITokenContext.SetToken()", exception.Message);
+    }
+}

--- a/Frenetik.iRacingApiWrapper/Service/BearerTokenDelegatingHandler.cs
+++ b/Frenetik.iRacingApiWrapper/Service/BearerTokenDelegatingHandler.cs
@@ -8,6 +8,14 @@ namespace Frenetik.iRacingApiWrapper.Service;
 /// External requests (S3, CDN, etc.) are passed through without authentication.
 /// Supports both single-user (via ITokenProvider) and multi-user scenarios (via ITokenContext).
 /// </summary>
+/// <remarks>
+/// This handler has been split into two focused handlers for better separation of concerns:
+/// <list type="bullet">
+/// <item><description>Use <see cref="PasswordLimitedTokenHandler"/> for single-user scenarios (Pattern 1)</description></item>
+/// <item><description>Use <see cref="TokenContextHandler"/> for multi-user scenarios (Pattern 2)</description></item>
+/// </list>
+/// </remarks>
+[Obsolete("Use PasswordLimitedTokenHandler for single-user scenarios or TokenContextHandler for multi-user scenarios. This class will be removed in a future version.")]
 public class BearerTokenDelegatingHandler : DelegatingHandler
 {
     private readonly ITokenProvider _tokenProvider;

--- a/Frenetik.iRacingApiWrapper/Service/NoOpTokenProvider.cs
+++ b/Frenetik.iRacingApiWrapper/Service/NoOpTokenProvider.cs
@@ -4,6 +4,11 @@ namespace Frenetik.iRacingApiWrapper.Service;
 /// A no-operation token provider for multi-user scenarios where tokens are provided per-request via ITokenContext.
 /// This provider returns an empty string and relies on the BearerTokenDelegatingHandler to use the token from ITokenContext instead.
 /// </summary>
+/// <remarks>
+/// This class is no longer needed when using <see cref="TokenContextHandler"/>, which doesn't require an ITokenProvider dependency.
+/// Only use this if you're still using the deprecated <see cref="BearerTokenDelegatingHandler"/>.
+/// </remarks>
+[Obsolete("Use TokenContextHandler instead, which doesn't require an ITokenProvider. This class will be removed in a future version.")]
 public class NoOpTokenProvider : ITokenProvider
 {
     /// <summary>

--- a/Frenetik.iRacingApiWrapper/Service/PasswordLimitedTokenHandler.cs
+++ b/Frenetik.iRacingApiWrapper/Service/PasswordLimitedTokenHandler.cs
@@ -1,0 +1,55 @@
+using Frenetik.iRacingApiWrapper.Config;
+using Microsoft.Extensions.Options;
+
+namespace Frenetik.iRacingApiWrapper.Service;
+
+/// <summary>
+/// DelegatingHandler for single-user scenarios using PasswordLimitedTokenProvider.
+/// Adds bearer token authentication to iRacing API requests using ITokenProvider.
+/// External requests (S3, CDN, etc.) are passed through without authentication.
+/// </summary>
+public class PasswordLimitedTokenHandler : DelegatingHandler
+{
+    private readonly ITokenProvider _tokenProvider;
+    private readonly IRacingDataSettings _settings;
+
+    /// <summary>
+    /// Constructor for the PasswordLimitedTokenHandler
+    /// </summary>
+    /// <param name="tokenProvider">Token provider that supplies bearer tokens</param>
+    /// <param name="settings">iRacing settings containing the base URL</param>
+    public PasswordLimitedTokenHandler(
+        ITokenProvider tokenProvider,
+        IOptions<IRacingDataSettings> settings)
+    {
+        _tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings.Value;
+    }
+
+    /// <summary>
+    /// Sends an HTTP request, adding bearer token authentication only for iRacing API requests.
+    /// </summary>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        // Only add authentication for iRacing base URL requests
+        // External URLs (S3, CDN, etc.) should not include Authorization header
+        if (request.RequestUri != null &&
+            request.RequestUri.AbsoluteUri.StartsWith(_settings.BaseUrl, StringComparison.OrdinalIgnoreCase))
+        {
+            var token = await _tokenProvider.GetTokenAsync(cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new InvalidOperationException(
+                    "No bearer token available from ITokenProvider. Ensure PasswordLimitedTokenProvider is configured correctly.");
+            }
+
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/Frenetik.iRacingApiWrapper/Service/TokenContextHandler.cs
+++ b/Frenetik.iRacingApiWrapper/Service/TokenContextHandler.cs
@@ -1,0 +1,56 @@
+using Frenetik.iRacingApiWrapper.Config;
+using Microsoft.Extensions.Options;
+
+namespace Frenetik.iRacingApiWrapper.Service;
+
+/// <summary>
+/// DelegatingHandler for multi-user scenarios using ITokenContext.
+/// Adds bearer token authentication to iRacing API requests using per-request tokens set via ITokenContext.SetToken().
+/// External requests (S3, CDN, etc.) are passed through without authentication.
+/// </summary>
+public class TokenContextHandler : DelegatingHandler
+{
+    private readonly ITokenContext _tokenContext;
+    private readonly IRacingDataSettings _settings;
+
+    /// <summary>
+    /// Constructor for the TokenContextHandler
+    /// </summary>
+    /// <param name="tokenContext">Token context for per-request tokens in multi-user scenarios</param>
+    /// <param name="settings">iRacing settings containing the base URL</param>
+    public TokenContextHandler(
+        ITokenContext tokenContext,
+        IOptions<IRacingDataSettings> settings)
+    {
+        _tokenContext = tokenContext ?? throw new ArgumentNullException(nameof(tokenContext));
+        ArgumentNullException.ThrowIfNull(settings);
+        _settings = settings.Value;
+    }
+
+    /// <summary>
+    /// Sends an HTTP request, adding bearer token authentication only for iRacing API requests.
+    /// Uses the token set via ITokenContext.SetToken() for this request.
+    /// </summary>
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        // Only add authentication for iRacing base URL requests
+        // External URLs (S3, CDN, etc.) should not include Authorization header
+        if (request.RequestUri != null &&
+            request.RequestUri.AbsoluteUri.StartsWith(_settings.BaseUrl, StringComparison.OrdinalIgnoreCase))
+        {
+            var token = _tokenContext.CurrentToken;
+
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                throw new InvalidOperationException(
+                    "No bearer token available from ITokenContext. Ensure ITokenContext.SetToken() is called before making API requests.");
+            }
+
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ services.Configure<PasswordLimitedTokenProviderSettings>(options =>
 
 // Register services
 services.AddHttpClient(IRacingApiService.HttpClientName)
-    .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
+    .AddHttpMessageHandler<PasswordLimitedTokenHandler>();
 
-services.AddTransient<BearerTokenDelegatingHandler>();
+services.AddTransient<PasswordLimitedTokenHandler>();
 services.AddSingleton<ITokenProvider, PasswordLimitedTokenProvider>();
 services.AddSingleton<IIRacingApiService, IRacingApiService>();
 services.AddLogging();
@@ -101,9 +101,9 @@ services.Configure<PasswordLimitedTokenProviderSettings>(
     Configuration.GetSection("OAuth"));
 
 services.AddHttpClient(IRacingApiService.HttpClientName)
-    .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
+    .AddHttpMessageHandler<PasswordLimitedTokenHandler>();
 
-services.AddTransient<BearerTokenDelegatingHandler>();
+services.AddTransient<PasswordLimitedTokenHandler>();
 services.AddSingleton<ITokenProvider, PasswordLimitedTokenProvider>();
 services.AddSingleton<IIRacingApiService, IRacingApiService>();
 ```
@@ -126,10 +126,9 @@ services.AddSingleton<IIRacingApiService, IRacingApiService>();
 ```csharp
 services.AddSingleton<ITokenContext, TokenContext>();
 services.AddHttpClient(IRacingApiService.HttpClientName)
-    .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
+    .AddHttpMessageHandler<TokenContextHandler>();
 
-services.AddTransient<BearerTokenDelegatingHandler>();
-services.AddSingleton<ITokenProvider, NoOpTokenProvider>();
+services.AddTransient<TokenContextHandler>();
 services.AddSingleton<IIRacingApiService, IRacingApiService>();
 ```
 

--- a/TestWrapper.Bearer/Program.cs
+++ b/TestWrapper.Bearer/Program.cs
@@ -10,14 +10,10 @@ services.AddSingleton<ITokenContext, TokenContext>();
 // Register HTTP client with authentication handler
 services.AddHttpClient(IRacingApiService.HttpClientName)
     .SetHandlerLifetime(TimeSpan.FromMinutes(5))
-    .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
+    .AddHttpMessageHandler<TokenContextHandler>();
 
 // Register services
-services.AddTransient<BearerTokenDelegatingHandler>();
-
-// Use NoOpTokenProvider since tokens come from context
-services.AddSingleton<ITokenProvider, NoOpTokenProvider>();
-
+services.AddTransient<TokenContextHandler>();
 services.AddSingleton<IRacingApiService>();
 services.AddLogging();
 

--- a/TestWrapper.PasswordLimited/Program.cs
+++ b/TestWrapper.PasswordLimited/Program.cs
@@ -32,10 +32,10 @@ internal class Program
         // Register HTTP client
         services.AddHttpClient(IRacingApiService.HttpClientName)
             .SetHandlerLifetime(TimeSpan.FromMinutes(5))
-            .AddHttpMessageHandler<BearerTokenDelegatingHandler>();
+            .AddHttpMessageHandler<PasswordLimitedTokenHandler>();
 
         // Register services
-        services.AddTransient<BearerTokenDelegatingHandler>();
+        services.AddTransient<PasswordLimitedTokenHandler>();
         services.AddSingleton<ITokenProvider, PasswordLimitedTokenProvider>();
         services.AddSingleton<IRacingApiService>();
 


### PR DESCRIPTION
Splitting up BearerTokenDelegatingHandler, the logic was messy inside.  Now you can instantiate one or the other flow of either directly providing a token via a registered ITokenContext or you can use the built-in PasswordLimitedTokenProvider.